### PR TITLE
Harden Azure signing hook execution

### DIFF
--- a/scripts/azure-sign.cjs
+++ b/scripts/azure-sign.cjs
@@ -12,6 +12,7 @@ const { spawnSync } = require('node:child_process');
 
 const REQUIRED_ENV_VARS = ['SIGNTOOL_PATH', 'AZURE_CODE_SIGNING_DLIB', 'AZURE_METADATA_JSON'];
 const DEFAULT_SIGNTOOL_TIMEOUT_MS = 10 * 60 * 1000;
+const MAX_SIGNTOOL_TIMEOUT_MS = 60 * 60 * 1000;
 
 function nonBlank(value) {
   return typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined;
@@ -28,7 +29,11 @@ function signtoolTimeoutMs(env) {
   }
 
   const timeout = Number.parseInt(rawTimeout, 10);
-  return timeout > 0 ? timeout : DEFAULT_SIGNTOOL_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeout) || timeout <= 0 || timeout > MAX_SIGNTOOL_TIMEOUT_MS) {
+    return DEFAULT_SIGNTOOL_TIMEOUT_MS;
+  }
+
+  return timeout;
 }
 
 function debugEnabled(env) {
@@ -43,6 +48,7 @@ function buildSigntoolArgs(file, env) {
   const args = [
     'sign',
     '/v',
+    ...(debugEnabled(env) ? ['/debug'] : []),
     '/fd', fileDigest,
     '/tr', timestampServer,
     '/td', timestampDigest,
@@ -50,11 +56,6 @@ function buildSigntoolArgs(file, env) {
     '/dmdf', nonBlank(env.AZURE_METADATA_JSON),
     file,
   ];
-
-  // `/debug` can expose Azure account/profile diagnostics in CI logs, so keep it opt-in.
-  if (debugEnabled(env)) {
-    args.splice(2, 0, '/debug');
-  }
 
   return args;
 }

--- a/scripts/azure-sign.cjs
+++ b/scripts/azure-sign.cjs
@@ -11,6 +11,7 @@
 const { spawnSync } = require('node:child_process');
 
 const REQUIRED_ENV_VARS = ['SIGNTOOL_PATH', 'AZURE_CODE_SIGNING_DLIB', 'AZURE_METADATA_JSON'];
+const DEFAULT_SIGNTOOL_TIMEOUT_MS = 10 * 60 * 1000;
 
 function nonBlank(value) {
   return typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined;
@@ -20,17 +21,28 @@ function shouldSign(env) {
   return REQUIRED_ENV_VARS.every((name) => nonBlank(env[name]) !== undefined);
 }
 
+function signtoolTimeoutMs(env) {
+  const rawTimeout = nonBlank(env.SIGNTOOL_TIMEOUT);
+  if (rawTimeout === undefined || !/^\d+$/.test(rawTimeout)) {
+    return DEFAULT_SIGNTOOL_TIMEOUT_MS;
+  }
+
+  const timeout = Number.parseInt(rawTimeout, 10);
+  return timeout > 0 ? timeout : DEFAULT_SIGNTOOL_TIMEOUT_MS;
+}
+
+function debugEnabled(env) {
+  return ['1', 'true', 'yes'].includes((nonBlank(env.AZURE_SIGN_DEBUG) || '').toLowerCase());
+}
+
 function buildSigntoolArgs(file, env) {
   const fileDigest = nonBlank(env.AZURE_FILE_DIGEST) || 'SHA256';
   const timestampServer = nonBlank(env.AZURE_TIMESTAMP_SERVER) || 'http://timestamp.acs.microsoft.com';
   const timestampDigest = nonBlank(env.AZURE_TIMESTAMP_DIGEST) || 'SHA256';
 
-  // `/debug` surfaces Azure auth/quota/network diagnostics on failure instead of a generic
-  // SignTool error.
-  return [
+  const args = [
     'sign',
     '/v',
-    '/debug',
     '/fd', fileDigest,
     '/tr', timestampServer,
     '/td', timestampDigest,
@@ -38,6 +50,13 @@ function buildSigntoolArgs(file, env) {
     '/dmdf', nonBlank(env.AZURE_METADATA_JSON),
     file,
   ];
+
+  // `/debug` can expose Azure account/profile diagnostics in CI logs, so keep it opt-in.
+  if (debugEnabled(env)) {
+    args.splice(2, 0, '/debug');
+  }
+
+  return args;
 }
 
 module.exports = async function sign(configuration) {
@@ -52,9 +71,16 @@ module.exports = async function sign(configuration) {
   }
 
   console.log(`[azure-sign] Signing ${file} with Azure Trusted Signing`);
-  const result = spawnSync(nonBlank(env.SIGNTOOL_PATH), buildSigntoolArgs(file, env), { stdio: 'inherit' });
+  const timeout = signtoolTimeoutMs(env);
+  const result = spawnSync(nonBlank(env.SIGNTOOL_PATH), buildSigntoolArgs(file, env), {
+    stdio: 'inherit',
+    timeout,
+  });
 
   if (result.error) {
+    if (result.error.code === 'ETIMEDOUT') {
+      throw new Error(`[azure-sign] signtool timed out after ${timeout}ms signing ${file}`);
+    }
     throw result.error;
   }
   if (result.signal) {
@@ -67,3 +93,4 @@ module.exports = async function sign(configuration) {
 
 module.exports.shouldSign = shouldSign;
 module.exports.buildSigntoolArgs = buildSigntoolArgs;
+module.exports.signtoolTimeoutMs = signtoolTimeoutMs;

--- a/scripts/azure-sign.cjs
+++ b/scripts/azure-sign.cjs
@@ -48,6 +48,7 @@ function buildSigntoolArgs(file, env) {
   const args = [
     'sign',
     '/v',
+    // /Debug surfaces Azure auth/quota/network diagnostics on failure instead of a generic SignTool error
     ...(debugEnabled(env) ? ['/debug'] : []),
     '/fd', fileDigest,
     '/tr', timestampServer,

--- a/test/azure-sign.test.cjs
+++ b/test/azure-sign.test.cjs
@@ -48,6 +48,7 @@ test('buildSigntoolArgs includes debug diagnostics only when enabled', () => {
   const args = buildSigntoolArgs('app.exe', { ...FULL_ENV, AZURE_SIGN_DEBUG: 'true' });
 
   assert.ok(args.includes('/debug'));
+  assert.deepEqual(args.slice(0, 6), ['sign', '/v', '/debug', '/fd', 'SHA256', '/tr']);
 });
 
 test('buildSigntoolArgs trims surrounding whitespace from dlib and metadata paths', () => {
@@ -99,4 +100,9 @@ test('signtoolTimeoutMs ignores blank, invalid, and zero SIGNTOOL_TIMEOUT values
   assert.equal(signtoolTimeoutMs({ SIGNTOOL_TIMEOUT: '   ' }), 10 * 60 * 1000);
   assert.equal(signtoolTimeoutMs({ SIGNTOOL_TIMEOUT: 'soon' }), 10 * 60 * 1000);
   assert.equal(signtoolTimeoutMs({ SIGNTOOL_TIMEOUT: '0' }), 10 * 60 * 1000);
+});
+
+test('signtoolTimeoutMs ignores unsafe and over-limit SIGNTOOL_TIMEOUT values', () => {
+  assert.equal(signtoolTimeoutMs({ SIGNTOOL_TIMEOUT: '3600001' }), 10 * 60 * 1000);
+  assert.equal(signtoolTimeoutMs({ SIGNTOOL_TIMEOUT: '999999999999999999999999999999999999999' }), 10 * 60 * 1000);
 });

--- a/test/azure-sign.test.cjs
+++ b/test/azure-sign.test.cjs
@@ -1,7 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 
-const { shouldSign, buildSigntoolArgs } = require('../scripts/azure-sign.cjs');
+const { shouldSign, buildSigntoolArgs, signtoolTimeoutMs } = require('../scripts/azure-sign.cjs');
 
 const FULL_ENV = {
   SIGNTOOL_PATH: 'C:/sdk/x64/signtool.exe',
@@ -41,6 +41,13 @@ test('buildSigntoolArgs signs SHA256-only with dlib, metadata, timestamp, and ta
   assert.equal(valueAfter(args, '/dmdf'), FULL_ENV.AZURE_METADATA_JSON);
   assert.equal(args.at(-1), 'app.exe');
   assert.ok(!args.includes('SHA1'));
+  assert.ok(!args.includes('/debug'));
+});
+
+test('buildSigntoolArgs includes debug diagnostics only when enabled', () => {
+  const args = buildSigntoolArgs('app.exe', { ...FULL_ENV, AZURE_SIGN_DEBUG: 'true' });
+
+  assert.ok(args.includes('/debug'));
 });
 
 test('buildSigntoolArgs trims surrounding whitespace from dlib and metadata paths', () => {
@@ -78,4 +85,18 @@ test('buildSigntoolArgs honors the toolkit-exported digest/timestamp overrides',
   assert.equal(valueAfter(args, '/fd'), 'SHA384');
   assert.equal(valueAfter(args, '/tr'), 'http://ts.example/test');
   assert.equal(valueAfter(args, '/td'), 'SHA512');
+});
+
+test('signtoolTimeoutMs defaults to ten minutes', () => {
+  assert.equal(signtoolTimeoutMs({}), 10 * 60 * 1000);
+});
+
+test('signtoolTimeoutMs honors positive SIGNTOOL_TIMEOUT values', () => {
+  assert.equal(signtoolTimeoutMs({ SIGNTOOL_TIMEOUT: '30000' }), 30000);
+});
+
+test('signtoolTimeoutMs ignores blank, invalid, and zero SIGNTOOL_TIMEOUT values', () => {
+  assert.equal(signtoolTimeoutMs({ SIGNTOOL_TIMEOUT: '   ' }), 10 * 60 * 1000);
+  assert.equal(signtoolTimeoutMs({ SIGNTOOL_TIMEOUT: 'soon' }), 10 * 60 * 1000);
+  assert.equal(signtoolTimeoutMs({ SIGNTOOL_TIMEOUT: '0' }), 10 * 60 * 1000);
 });


### PR DESCRIPTION
Follow-up hardening from the PR 21 Windows signing review.

This keeps the Azure Trusted Signing hook behavior the same for CI, but makes execution safer:

- adds a SIGNTOOL_TIMEOUT-backed timeout around the synchronous signtool call
- reports timeout failures with file context
- makes /debug opt-in through AZURE_SIGN_DEBUG to avoid verbose Azure diagnostics in routine CI logs
- expands node:test coverage for timeout parsing and debug argument construction

This PR is intentionally scoped to the Node hook. Windows Buildkite artifact and signer verification hardening is split into a stacked follow-up PR.