### PR TITLE
Surface site path inline with a quick copy button

### DIFF
--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -13912,7 +13912,7 @@
           }
           function pushStoreConsistencyCheck(fiber, getSnapshot, renderedSnapshot) {
             fiber.flags |= StoreConsistency;
-            var check = {
+            var check2 = {
               getSnapshot,
               value: renderedSnapshot
             };
@@ -13920,13 +13920,13 @@
             if (componentUpdateQueue === null) {
               componentUpdateQueue = createFunctionComponentUpdateQueue();
               currentlyRenderingFiber$1.updateQueue = componentUpdateQueue;
-              componentUpdateQueue.stores = [check];
+              componentUpdateQueue.stores = [check2];
             } else {
               var stores = componentUpdateQueue.stores;
               if (stores === null) {
-                componentUpdateQueue.stores = [check];
+                componentUpdateQueue.stores = [check2];
               } else {
-                stores.push(check);
+                stores.push(check2);
               }
             }
           }
@@ -20786,9 +20786,9 @@
                   var checks = updateQueue.stores;
                   if (checks !== null) {
                     for (var i = 0; i < checks.length; i++) {
-                      var check = checks[i];
-                      var getSnapshot = check.getSnapshot;
-                      var renderedValue = check.value;
+                      var check2 = checks[i];
+                      var getSnapshot = check2.getSnapshot;
+                      var renderedValue = check2.value;
                       try {
                         if (!objectIs(getSnapshot(), renderedValue)) {
                           return false;
@@ -41555,10 +41555,10 @@ If there's a particular need for this, please submit a feature request at https:
     }
     return React6.createElement.apply(null, createElementArgArray);
   };
-  (function(_jsx41) {
+  (function(_jsx42) {
     var JSX;
     /* @__PURE__ */ (function(_JSX) {
-    })(JSX || (JSX = _jsx41.JSX || (_jsx41.JSX = {})));
+    })(JSX || (JSX = _jsx42.JSX || (_jsx42.JSX = {})));
   })(jsx17 || (jsx17 = {}));
   function css() {
     for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
@@ -42405,13 +42405,13 @@ If there's a particular need for this, please submit a feature request at https:
   var warning2 = noop2;
   var invariant2 = noop2;
   if (true) {
-    warning2 = (check, message) => {
-      if (!check && typeof console !== "undefined") {
+    warning2 = (check2, message) => {
+      if (!check2 && typeof console !== "undefined") {
         console.warn(message);
       }
     };
-    invariant2 = (check, message) => {
-      if (!check) {
+    invariant2 = (check2, message) => {
+      if (!check2) {
         throw new Error(message);
       }
     };
@@ -50249,45 +50249,56 @@ If there's a particular need for this, please submit a feature request at https:
   var Spacer = contextConnect(UnconnectedSpacer, "Spacer");
   var component_default4 = Spacer;
 
-  // node_modules/@wordpress/icons/build-module/library/chevron-left.js
+  // node_modules/@wordpress/icons/build-module/library/check.js
   var import_jsx_runtime27 = __toESM(require_jsx_runtime());
-  var chevronLeft = /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(SVG, {
+  var check = /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(SVG, {
     xmlns: "http://www.w3.org/2000/svg",
     viewBox: "0 0 24 24",
     children: /* @__PURE__ */ (0, import_jsx_runtime27.jsx)(Path, {
+      d: "M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"
+    })
+  });
+  var check_default = check;
+
+  // node_modules/@wordpress/icons/build-module/library/chevron-left.js
+  var import_jsx_runtime28 = __toESM(require_jsx_runtime());
+  var chevronLeft = /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(SVG, {
+    xmlns: "http://www.w3.org/2000/svg",
+    viewBox: "0 0 24 24",
+    children: /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(Path, {
       d: "M14.6 7l-1.2-1L8 12l5.4 6 1.2-1-4.6-5z"
     })
   });
   var chevron_left_default = chevronLeft;
 
   // node_modules/@wordpress/icons/build-module/library/chevron-right.js
-  var import_jsx_runtime28 = __toESM(require_jsx_runtime());
-  var chevronRight = /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(SVG, {
+  var import_jsx_runtime29 = __toESM(require_jsx_runtime());
+  var chevronRight = /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(SVG, {
     xmlns: "http://www.w3.org/2000/svg",
     viewBox: "0 0 24 24",
-    children: /* @__PURE__ */ (0, import_jsx_runtime28.jsx)(Path, {
+    children: /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(Path, {
       d: "M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z"
     })
   });
   var chevron_right_default = chevronRight;
 
   // node_modules/@wordpress/icons/build-module/library/close.js
-  var import_jsx_runtime29 = __toESM(require_jsx_runtime());
-  var close = /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(SVG, {
+  var import_jsx_runtime30 = __toESM(require_jsx_runtime());
+  var close = /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(SVG, {
     xmlns: "http://www.w3.org/2000/svg",
     viewBox: "0 0 24 24",
-    children: /* @__PURE__ */ (0, import_jsx_runtime29.jsx)(Path, {
+    children: /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(Path, {
       d: "m13.06 12 6.47-6.47-1.06-1.06L12 10.94 5.53 4.47 4.47 5.53 10.94 12l-6.47 6.47 1.06 1.06L12 13.06l6.47 6.47 1.06-1.06L13.06 12Z"
     })
   });
   var close_default = close;
 
   // node_modules/@wordpress/icons/build-module/library/copy.js
-  var import_jsx_runtime30 = __toESM(require_jsx_runtime());
-  var copy2 = /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(SVG, {
+  var import_jsx_runtime31 = __toESM(require_jsx_runtime());
+  var copy2 = /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(SVG, {
     xmlns: "http://www.w3.org/2000/svg",
     viewBox: "0 0 24 24",
-    children: /* @__PURE__ */ (0, import_jsx_runtime30.jsx)(Path, {
+    children: /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Path, {
       fillRule: "evenodd",
       clipRule: "evenodd",
       d: "M5 4.5h11a.5.5 0 0 1 .5.5v11a.5.5 0 0 1-.5.5H5a.5.5 0 0 1-.5-.5V5a.5.5 0 0 1 .5-.5ZM3 5a2 2 0 0 1 2-2h11a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5Zm17 3v10.75c0 .69-.56 1.25-1.25 1.25H6v1.5h12.75a2.75 2.75 0 0 0 2.75-2.75V8H20Z"
@@ -50296,22 +50307,22 @@ If there's a particular need for this, please submit a feature request at https:
   var copy_default = copy2;
 
   // node_modules/@wordpress/icons/build-module/library/download.js
-  var import_jsx_runtime31 = __toESM(require_jsx_runtime());
-  var download = /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(SVG, {
+  var import_jsx_runtime32 = __toESM(require_jsx_runtime());
+  var download = /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(SVG, {
     xmlns: "http://www.w3.org/2000/svg",
     viewBox: "0 0 24 24",
-    children: /* @__PURE__ */ (0, import_jsx_runtime31.jsx)(Path, {
+    children: /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Path, {
       d: "M18 11.3l-1-1.1-4 4V3h-1.5v11.3L7 10.2l-1 1.1 6.2 5.8 5.8-5.8zm.5 3.7v3.5h-13V15H4v5h16v-5h-1.5z"
     })
   });
   var download_default = download;
 
   // node_modules/@wordpress/icons/build-module/library/pencil.js
-  var import_jsx_runtime32 = __toESM(require_jsx_runtime());
-  var pencil = /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(SVG, {
+  var import_jsx_runtime33 = __toESM(require_jsx_runtime());
+  var pencil = /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(SVG, {
     xmlns: "http://www.w3.org/2000/svg",
     viewBox: "0 0 24 24",
-    children: /* @__PURE__ */ (0, import_jsx_runtime32.jsx)(Path, {
+    children: /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(Path, {
       d: "m19 7-3-3-8.5 8.5-1 4 4-1L19 7Zm-7 11.5H5V20h7v-1.5Z"
     })
   });
@@ -50321,22 +50332,22 @@ If there's a particular need for this, please submit a feature request at https:
   var edit_default = pencil_default;
 
   // node_modules/@wordpress/icons/build-module/library/menu.js
-  var import_jsx_runtime33 = __toESM(require_jsx_runtime());
-  var menu = /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(SVG, {
+  var import_jsx_runtime34 = __toESM(require_jsx_runtime());
+  var menu = /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(SVG, {
     xmlns: "http://www.w3.org/2000/svg",
     viewBox: "0 0 24 24",
-    children: /* @__PURE__ */ (0, import_jsx_runtime33.jsx)(Path, {
+    children: /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(Path, {
       d: "M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z"
     })
   });
   var menu_default = menu;
 
   // node_modules/@wordpress/icons/build-module/library/plus.js
-  var import_jsx_runtime34 = __toESM(require_jsx_runtime());
-  var plus = /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(SVG, {
+  var import_jsx_runtime35 = __toESM(require_jsx_runtime());
+  var plus = /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(SVG, {
     xmlns: "http://www.w3.org/2000/svg",
     viewBox: "0 0 24 24",
-    children: /* @__PURE__ */ (0, import_jsx_runtime34.jsx)(Path, {
+    children: /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(Path, {
       d: "M11 12.5V17.5H12.5V12.5H17.5V11H12.5V6H11V11H6V12.5H11Z"
     })
   });
@@ -50414,7 +50425,7 @@ If there's a particular need for this, please submit a feature request at https:
   })(labelStyles, ";" + (false ? "" : "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIkB3b3JkcHJlc3MvY29tcG9uZW50cy9zcmMvYmFzZS1jb250cm9sL3N0eWxlcy9iYXNlLWNvbnRyb2wtc3R5bGVzLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQXVFNEMiLCJmaWxlIjoiQHdvcmRwcmVzcy9jb21wb25lbnRzL3NyYy9iYXNlLWNvbnRyb2wvc3R5bGVzL2Jhc2UtY29udHJvbC1zdHlsZXMudHMiLCJzb3VyY2VzQ29udGVudCI6WyIvKipcbiAqIEV4dGVybmFsIGRlcGVuZGVuY2llc1xuICovXG5pbXBvcnQgc3R5bGVkIGZyb20gJ0BlbW90aW9uL3N0eWxlZCc7XG5pbXBvcnQgeyBjc3MgfSBmcm9tICdAZW1vdGlvbi9yZWFjdCc7XG5cbi8qKlxuICogSW50ZXJuYWwgZGVwZW5kZW5jaWVzXG4gKi9cbmltcG9ydCB7IGJhc2VMYWJlbFR5cG9ncmFwaHksIGJveFNpemluZ1Jlc2V0LCBmb250LCBDT0xPUlMgfSBmcm9tICcuLi8uLi91dGlscyc7XG5pbXBvcnQgeyBzcGFjZSB9IGZyb20gJy4uLy4uL3V0aWxzL3NwYWNlJztcblxuZXhwb3J0IGNvbnN0IFdyYXBwZXIgPSBzdHlsZWQuZGl2YFxuXHRmb250LWZhbWlseTogJHsgZm9udCggJ2RlZmF1bHQuZm9udEZhbWlseScgKSB9O1xuXHRmb250LXNpemU6ICR7IGZvbnQoICdkZWZhdWx0LmZvbnRTaXplJyApIH07XG5cblx0JHsgYm94U2l6aW5nUmVzZXQgfVxuYDtcblxuY29uc3QgZGVwcmVjYXRlZE1hcmdpbkZpZWxkID0gKCB7IF9fbmV4dEhhc05vTWFyZ2luQm90dG9tID0gZmFsc2UgfSApID0+IHtcblx0cmV0dXJuIChcblx0XHQhIF9fbmV4dEhhc05vTWFyZ2luQm90dG9tICYmXG5cdFx0Y3NzYFxuXHRcdFx0bWFyZ2luLWJvdHRvbTogJHsgc3BhY2UoIDIgKSB9O1xuXHRcdGBcblx0KTtcbn07XG5cbmV4cG9ydCBjb25zdCBTdHlsZWRGaWVsZCA9IHN0eWxlZC5kaXZgXG5cdCR7IGRlcHJlY2F0ZWRNYXJnaW5GaWVsZCB9XG5cblx0LmNvbXBvbmVudHMtcGFuZWxfX3JvdyAmIHtcblx0XHRtYXJnaW4tYm90dG9tOiBpbmhlcml0O1xuXHR9XG5gO1xuXG5jb25zdCBsYWJlbFN0eWxlcyA9IGNzc2Bcblx0JHsgYmFzZUxhYmVsVHlwb2dyYXBoeSB9O1xuXG5cdGRpc3BsYXk6IGJsb2NrO1xuXHRtYXJnaW4tYm90dG9tOiAkeyBzcGFjZSggMiApIH07XG5cdC8qKlxuXHQgKiBSZW1vdmVzIENocm9tZS9TYWZhcmkvRmlyZWZveCB1c2VyIGFnZW50IHN0eWxlc2hlZXQgcGFkZGluZyBmcm9tXG5cdCAqIFN0eWxlZExhYmVsIHdoZW4gaXQgaXMgcmVuZGVyZWQgYXMgYSBsZWdlbmQuXG5cdCAqL1xuXHRwYWRkaW5nOiAwO1xuYDtcblxuZXhwb3J0IGNvbnN0IFN0eWxlZExhYmVsID0gc3R5bGVkLmxhYmVsYFxuXHQkeyBsYWJlbFN0eWxlcyB9XG5gO1xuXG5jb25zdCBkZXByZWNhdGVkTWFyZ2luSGVscCA9ICggeyBfX25leHRIYXNOb01hcmdpbkJvdHRvbSA9IGZhbHNlIH0gKSA9PiB7XG5cdHJldHVybiAoXG5cdFx0ISBfX25leHRIYXNOb01hcmdpbkJvdHRvbSAmJlxuXHRcdGNzc2Bcblx0XHRcdG1hcmdpbi1ib3R0b206IHJldmVydDtcblx0XHRgXG5cdCk7XG59O1xuXG5leHBvcnQgY29uc3QgU3R5bGVkSGVscCA9IHN0eWxlZC5wYFxuXHRtYXJnaW4tdG9wOiAkeyBzcGFjZSggMiApIH07XG5cdG1hcmdpbi1ib3R0b206IDA7XG5cdGZvbnQtc2l6ZTogJHsgZm9udCggJ2hlbHBUZXh0LmZvbnRTaXplJyApIH07XG5cdGZvbnQtc3R5bGU6IG5vcm1hbDtcblx0Y29sb3I6ICR7IENPTE9SUy5ncmF5WyA3MDAgXSB9O1xuXG5cdCR7IGRlcHJlY2F0ZWRNYXJnaW5IZWxwIH1cbmA7XG5cbmV4cG9ydCBjb25zdCBTdHlsZWRWaXN1YWxMYWJlbCA9IHN0eWxlZC5zcGFuYFxuXHQkeyBsYWJlbFN0eWxlcyB9XG5gO1xuIl19 */"));
 
   // node_modules/@wordpress/components/build-module/base-control/index.js
-  var import_jsx_runtime35 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime36 = __toESM(require_jsx_runtime());
   var UnconnectedBaseControl = (props) => {
     const {
       __nextHasNoMarginBottom = false,
@@ -50433,26 +50444,26 @@ If there's a particular need for this, please submit a feature request at https:
         hint: "Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version."
       });
     }
-    return /* @__PURE__ */ (0, import_jsx_runtime35.jsxs)(Wrapper, {
+    return /* @__PURE__ */ (0, import_jsx_runtime36.jsxs)(Wrapper, {
       className,
-      children: [/* @__PURE__ */ (0, import_jsx_runtime35.jsxs)(StyledField, {
+      children: [/* @__PURE__ */ (0, import_jsx_runtime36.jsxs)(StyledField, {
         className: "components-base-control__field",
         __nextHasNoMarginBottom,
-        children: [label && id3 && (hideLabelFromVision ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(component_default2, {
+        children: [label && id3 && (hideLabelFromVision ? /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(component_default2, {
           as: "label",
           htmlFor: id3,
           children: label
-        }) : /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(StyledLabel, {
+        }) : /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(StyledLabel, {
           className: "components-base-control__label",
           htmlFor: id3,
           children: label
-        })), label && !id3 && (hideLabelFromVision ? /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(component_default2, {
+        })), label && !id3 && (hideLabelFromVision ? /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(component_default2, {
           as: "label",
           children: label
-        }) : /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(VisualLabel, {
+        }) : /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(VisualLabel, {
           children: label
         })), children]
-      }), !!help && /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(StyledHelp, {
+      }), !!help && /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(StyledHelp, {
         id: id3 ? id3 + "__help" : void 0,
         className: "components-base-control__help",
         __nextHasNoMarginBottom,
@@ -50466,7 +50477,7 @@ If there's a particular need for this, please submit a feature request at https:
       children,
       ...restProps
     } = props;
-    return /* @__PURE__ */ (0, import_jsx_runtime35.jsx)(StyledVisualLabel, {
+    return /* @__PURE__ */ (0, import_jsx_runtime36.jsx)(StyledVisualLabel, {
       ref,
       ...restProps,
       className: clsx_default("components-base-control__label", className),
@@ -50501,7 +50512,7 @@ If there's a particular need for this, please submit a feature request at https:
   var base_control_default = BaseControl;
 
   // node_modules/@wordpress/components/build-module/dashicon/index.js
-  var import_jsx_runtime36 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime37 = __toESM(require_jsx_runtime());
   function Dashicon({
     icon,
     className,
@@ -50523,7 +50534,7 @@ If there's a particular need for this, please submit a feature request at https:
       ...sizeStyles,
       ...style
     };
-    return /* @__PURE__ */ (0, import_jsx_runtime36.jsx)("span", {
+    return /* @__PURE__ */ (0, import_jsx_runtime37.jsx)("span", {
       className: iconClass,
       style: styles,
       ...extraProps
@@ -50532,14 +50543,14 @@ If there's a particular need for this, please submit a feature request at https:
   var dashicon_default = Dashicon;
 
   // node_modules/@wordpress/components/build-module/icon/index.js
-  var import_jsx_runtime37 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime38 = __toESM(require_jsx_runtime());
   function Icon({
     icon = null,
     size: size4 = "string" === typeof icon ? 20 : 24,
     ...additionalProps
   }) {
     if ("string" === typeof icon) {
-      return /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(dashicon_default, {
+      return /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(dashicon_default, {
         icon,
         size: size4,
         ...additionalProps
@@ -50563,7 +50574,7 @@ If there's a particular need for this, please submit a feature request at https:
         height: size4,
         ...additionalProps
       };
-      return /* @__PURE__ */ (0, import_jsx_runtime37.jsx)(SVG, {
+      return /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(SVG, {
         ...appliedProps
       });
     }
@@ -50579,7 +50590,7 @@ If there's a particular need for this, please submit a feature request at https:
   var icon_default = Icon;
 
   // node_modules/@wordpress/components/build-module/button/index.js
-  var import_jsx_runtime38 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime39 = __toESM(require_jsx_runtime());
   var disabledEventsOnDisabledButton = ["onMouseDown", "onClick"];
   function useDeprecatedProps2({
     __experimentalIsFocusable,
@@ -50731,24 +50742,24 @@ If there's a particular need for this, please submit a feature request at https:
       "aria-describedby": describedById,
       ref
     };
-    const elementChildren = /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)(import_jsx_runtime38.Fragment, {
-      children: [icon && iconPosition === "left" && /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(icon_default, {
+    const elementChildren = /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)(import_jsx_runtime39.Fragment, {
+      children: [icon && iconPosition === "left" && /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(icon_default, {
         icon,
         size: iconSize
-      }), text && /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(import_jsx_runtime38.Fragment, {
+      }), text && /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(import_jsx_runtime39.Fragment, {
         children: text
-      }), children, icon && iconPosition === "right" && /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(icon_default, {
+      }), children, icon && iconPosition === "right" && /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(icon_default, {
         icon,
         size: iconSize
       })]
     });
-    const element = Tag === "a" ? /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("a", {
+    const element = Tag === "a" ? /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("a", {
       ...anchorProps,
       ...additionalProps,
       ...disableEventProps,
       ...commonProps,
       children: elementChildren
-    }) : /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("button", {
+    }) : /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("button", {
       ...buttonProps,
       ...additionalProps,
       ...disableEventProps,
@@ -50761,12 +50772,12 @@ If there's a particular need for this, please submit a feature request at https:
       placement: tooltipPosition && // Convert legacy `position` values to be used with the new `placement` prop
       positionToPlacement(tooltipPosition)
     } : {};
-    return /* @__PURE__ */ (0, import_jsx_runtime38.jsxs)(import_jsx_runtime38.Fragment, {
-      children: [/* @__PURE__ */ (0, import_jsx_runtime38.jsx)(tooltip_default, {
+    return /* @__PURE__ */ (0, import_jsx_runtime39.jsxs)(import_jsx_runtime39.Fragment, {
+      children: [/* @__PURE__ */ (0, import_jsx_runtime39.jsx)(tooltip_default, {
         ...tooltipProps,
         children: element
-      }), description && /* @__PURE__ */ (0, import_jsx_runtime38.jsx)(component_default2, {
-        children: /* @__PURE__ */ (0, import_jsx_runtime38.jsx)("span", {
+      }), description && /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(component_default2, {
+        children: /* @__PURE__ */ (0, import_jsx_runtime39.jsx)("span", {
           id: descriptionId,
           children: description
         })
@@ -51143,7 +51154,7 @@ If there's a particular need for this, please submit a feature request at https:
   }
 
   // node_modules/@wordpress/components/build-module/slot-fill/slot.js
-  var import_jsx_runtime39 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime40 = __toESM(require_jsx_runtime());
   function isFunction(maybeFunc) {
     return typeof maybeFunc === "function";
   }
@@ -51184,7 +51195,7 @@ If there's a particular need for this, please submit a feature request at https:
       // it allows us to render wrappers only when the fills are actually present.
       (element) => !isEmptyElement(element)
     );
-    return /* @__PURE__ */ (0, import_jsx_runtime39.jsx)(import_jsx_runtime39.Fragment, {
+    return /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(import_jsx_runtime40.Fragment, {
       children: isFunction(children) ? children(fills) : fills
     });
   }
@@ -51260,7 +51271,7 @@ If there's a particular need for this, please submit a feature request at https:
   var v4_default = v4;
 
   // node_modules/@wordpress/components/build-module/style-provider/index.js
-  var import_jsx_runtime40 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime41 = __toESM(require_jsx_runtime());
   var uuidCache = /* @__PURE__ */ new Set();
   var containerCacheMap = /* @__PURE__ */ new WeakMap();
   var memoizedCreateCacheWithContainer = (container) => {
@@ -51288,7 +51299,7 @@ If there's a particular need for this, please submit a feature request at https:
       return null;
     }
     const cache2 = memoizedCreateCacheWithContainer(document2.head);
-    return /* @__PURE__ */ (0, import_jsx_runtime40.jsx)(CacheProvider, {
+    return /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(CacheProvider, {
       value: cache2,
       children
     });
@@ -51296,7 +51307,7 @@ If there's a particular need for this, please submit a feature request at https:
   var style_provider_default = StyleProvider;
 
   // node_modules/@wordpress/components/build-module/slot-fill/bubbles-virtually/fill.js
-  var import_jsx_runtime41 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime42 = __toESM(require_jsx_runtime());
   function Fill2({
     name,
     children
@@ -51318,7 +51329,7 @@ If there's a particular need for this, please submit a feature request at https:
     if (!slot || !slot.ref.current) {
       return null;
     }
-    const wrappedChildren = /* @__PURE__ */ (0, import_jsx_runtime41.jsx)(style_provider_default, {
+    const wrappedChildren = /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(style_provider_default, {
       document: slot.ref.current.ownerDocument,
       children: typeof children === "function" ? children((_slot$fillProps = slot.fillProps) !== null && _slot$fillProps !== void 0 ? _slot$fillProps : {}) : children
     });
@@ -51326,7 +51337,7 @@ If there's a particular need for this, please submit a feature request at https:
   }
 
   // node_modules/@wordpress/components/build-module/slot-fill/bubbles-virtually/slot.js
-  var import_jsx_runtime42 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime43 = __toESM(require_jsx_runtime());
   function Slot2(props, forwardedRef) {
     const {
       name,
@@ -51356,7 +51367,7 @@ If there's a particular need for this, please submit a feature request at https:
     (0, import_react.useLayoutEffect)(() => {
       registry.updateSlot(name, ref, fillPropsRef.current);
     });
-    return /* @__PURE__ */ (0, import_jsx_runtime42.jsx)(component_default, {
+    return /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(component_default, {
       as,
       ref: useMergeRefs([forwardedRef, ref]),
       ...restProps
@@ -51365,7 +51376,7 @@ If there's a particular need for this, please submit a feature request at https:
   var slot_default2 = (0, import_react.forwardRef)(Slot2);
 
   // node_modules/@wordpress/components/build-module/slot-fill/bubbles-virtually/slot-fill-provider.js
-  var import_jsx_runtime43 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime44 = __toESM(require_jsx_runtime());
   function createSlotRegistry() {
     const slots = observableMap();
     const fills = observableMap();
@@ -51428,14 +51439,14 @@ If there's a particular need for this, please submit a feature request at https:
     children
   }) {
     const [registry] = (0, import_react.useState)(createSlotRegistry);
-    return /* @__PURE__ */ (0, import_jsx_runtime43.jsx)(slot_fill_context_default.Provider, {
+    return /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(slot_fill_context_default.Provider, {
       value: registry,
       children
     });
   }
 
   // node_modules/@wordpress/components/build-module/slot-fill/provider.js
-  var import_jsx_runtime44 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime45 = __toESM(require_jsx_runtime());
   function createSlotRegistry2() {
     const slots = {};
     const fills = {};
@@ -51503,7 +51514,7 @@ If there's a particular need for this, please submit a feature request at https:
     children
   }) {
     const [contextValue] = (0, import_react.useState)(createSlotRegistry2);
-    return /* @__PURE__ */ (0, import_jsx_runtime44.jsx)(context_default.Provider, {
+    return /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(context_default.Provider, {
       value: contextValue,
       children
     });
@@ -51511,7 +51522,7 @@ If there's a particular need for this, please submit a feature request at https:
   var provider_default = SlotFillProvider2;
 
   // node_modules/@wordpress/components/build-module/slot-fill/index.js
-  var import_jsx_runtime45 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime46 = __toESM(require_jsx_runtime());
 
   // node_modules/@wordpress/components/build-module/slot-fill/bubbles-virtually/use-slot.js
   function useSlot2(name) {
@@ -51524,10 +51535,10 @@ If there's a particular need for this, please submit a feature request at https:
 
   // node_modules/@wordpress/components/build-module/slot-fill/index.js
   function Fill3(props) {
-    return /* @__PURE__ */ (0, import_jsx_runtime45.jsxs)(import_jsx_runtime45.Fragment, {
-      children: [/* @__PURE__ */ (0, import_jsx_runtime45.jsx)(Fill, {
+    return /* @__PURE__ */ (0, import_jsx_runtime46.jsxs)(import_jsx_runtime46.Fragment, {
+      children: [/* @__PURE__ */ (0, import_jsx_runtime46.jsx)(Fill, {
         ...props
-      }), /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(Fill2, {
+      }), /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(Fill2, {
         ...props
       })]
     });
@@ -51538,12 +51549,12 @@ If there's a particular need for this, please submit a feature request at https:
       ...restProps
     } = props;
     if (bubblesVirtually) {
-      return /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(slot_default2, {
+      return /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(slot_default2, {
         ...restProps,
         ref
       });
     }
-    return /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(slot_default, {
+    return /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(slot_default, {
       ...restProps
     });
   }
@@ -51554,12 +51565,12 @@ If there's a particular need for this, please submit a feature request at https:
   }) {
     const parent = (0, import_react.useContext)(slot_fill_context_default);
     if (!parent.isDefault && passthrough) {
-      return /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(import_jsx_runtime45.Fragment, {
+      return /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(import_jsx_runtime46.Fragment, {
         children
       });
     }
-    return /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(provider_default, {
-      children: /* @__PURE__ */ (0, import_jsx_runtime45.jsx)(SlotFillProvider, {
+    return /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(provider_default, {
+      children: /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(SlotFillProvider, {
         children
       })
     });
@@ -51596,17 +51607,17 @@ If there's a particular need for this, please submit a feature request at https:
   }
 
   // node_modules/@wordpress/components/build-module/popover/index.js
-  var import_jsx_runtime46 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime47 = __toESM(require_jsx_runtime());
   var SLOT_NAME = "Popover";
-  var ArrowTriangle = () => /* @__PURE__ */ (0, import_jsx_runtime46.jsxs)(SVG, {
+  var ArrowTriangle = () => /* @__PURE__ */ (0, import_jsx_runtime47.jsxs)(SVG, {
     xmlns: "http://www.w3.org/2000/svg",
     viewBox: "0 0 100 100",
     className: "components-popover__triangle",
     role: "presentation",
-    children: [/* @__PURE__ */ (0, import_jsx_runtime46.jsx)(Path, {
+    children: [/* @__PURE__ */ (0, import_jsx_runtime47.jsx)(Path, {
       className: "components-popover__triangle-bg",
       d: "M 0 0 L 50 50 L 100 0"
-    }), /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(Path, {
+    }), /* @__PURE__ */ (0, import_jsx_runtime47.jsx)(Path, {
       className: "components-popover__triangle-border",
       d: "M 0 0 L 50 50 L 100 0",
       vectorEffect: "non-scaling-stroke"
@@ -51816,7 +51827,7 @@ If there's a particular need for this, please submit a feature request at https:
       }
     };
     const isPositioned = (!shouldAnimate || animationFinished) && x !== null && y !== null;
-    let content = /* @__PURE__ */ (0, import_jsx_runtime46.jsxs)(motion.div, {
+    let content = /* @__PURE__ */ (0, import_jsx_runtime47.jsxs)(motion.div, {
       className: clsx_default(className, {
         "is-expanded": isExpanded,
         "is-positioned": isPositioned,
@@ -51828,40 +51839,40 @@ If there's a particular need for this, please submit a feature request at https:
       ref: mergedFloatingRef,
       ...dialogProps,
       tabIndex: -1,
-      children: [isExpanded && /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(scroll_lock_default, {}), isExpanded && /* @__PURE__ */ (0, import_jsx_runtime46.jsxs)("div", {
+      children: [isExpanded && /* @__PURE__ */ (0, import_jsx_runtime47.jsx)(scroll_lock_default, {}), isExpanded && /* @__PURE__ */ (0, import_jsx_runtime47.jsxs)("div", {
         className: "components-popover__header",
-        children: [/* @__PURE__ */ (0, import_jsx_runtime46.jsx)("span", {
+        children: [/* @__PURE__ */ (0, import_jsx_runtime47.jsx)("span", {
           className: "components-popover__header-title",
           children: headerTitle
-        }), /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(button_default, {
+        }), /* @__PURE__ */ (0, import_jsx_runtime47.jsx)(button_default, {
           className: "components-popover__close",
           size: "small",
           icon: close_default,
           onClick: onClose,
           label: __("Close")
         })]
-      }), /* @__PURE__ */ (0, import_jsx_runtime46.jsx)("div", {
+      }), /* @__PURE__ */ (0, import_jsx_runtime47.jsx)("div", {
         className: "components-popover__content",
         children
-      }), hasArrow && /* @__PURE__ */ (0, import_jsx_runtime46.jsx)("div", {
+      }), hasArrow && /* @__PURE__ */ (0, import_jsx_runtime47.jsx)("div", {
         ref: arrowCallbackRef,
         className: ["components-popover__arrow", `is-${computedPlacement.split("-")[0]}`].join(" "),
         style: {
           left: typeof arrowData?.x !== "undefined" && Number.isFinite(arrowData.x) ? `${arrowData.x}px` : "",
           top: typeof arrowData?.y !== "undefined" && Number.isFinite(arrowData.y) ? `${arrowData.y}px` : ""
         },
-        children: /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(ArrowTriangle, {})
+        children: /* @__PURE__ */ (0, import_jsx_runtime47.jsx)(ArrowTriangle, {})
       })]
     });
     const shouldRenderWithinSlot = slot.ref && !inline3;
     const hasAnchor = anchorRef || anchorRect || anchor;
     if (shouldRenderWithinSlot) {
-      content = /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(Fill3, {
+      content = /* @__PURE__ */ (0, import_jsx_runtime47.jsx)(Fill3, {
         name: slotName,
         children: content
       });
     } else if (!inline3) {
-      content = (0, import_react_dom.createPortal)(/* @__PURE__ */ (0, import_jsx_runtime46.jsx)(StyleProvider, {
+      content = (0, import_react_dom.createPortal)(/* @__PURE__ */ (0, import_jsx_runtime47.jsx)(StyleProvider, {
         document,
         children: content
       }), getPopoverFallbackContainer());
@@ -51869,8 +51880,8 @@ If there's a particular need for this, please submit a feature request at https:
     if (hasAnchor) {
       return content;
     }
-    return /* @__PURE__ */ (0, import_jsx_runtime46.jsxs)(import_jsx_runtime46.Fragment, {
-      children: [/* @__PURE__ */ (0, import_jsx_runtime46.jsx)("span", {
+    return /* @__PURE__ */ (0, import_jsx_runtime47.jsxs)(import_jsx_runtime47.Fragment, {
+      children: [/* @__PURE__ */ (0, import_jsx_runtime47.jsx)("span", {
         ref: anchorRefFallback
       }), content]
     });
@@ -51879,7 +51890,7 @@ If there's a particular need for this, please submit a feature request at https:
   function PopoverSlot({
     name = SLOT_NAME
   }, ref) {
-    return /* @__PURE__ */ (0, import_jsx_runtime46.jsx)(Slot3, {
+    return /* @__PURE__ */ (0, import_jsx_runtime47.jsx)(Slot3, {
       bubblesVirtually: true,
       name,
       className: "popover-slot",
@@ -51908,7 +51919,7 @@ If there's a particular need for this, please submit a feature request at https:
   }
 
   // node_modules/@wordpress/components/build-module/dropdown/index.js
-  var import_jsx_runtime47 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime48 = __toESM(require_jsx_runtime());
   var UnconnectedDropdown = (props, forwardedRef) => {
     const {
       renderContent,
@@ -51967,12 +51978,12 @@ If there's a particular need for this, please submit a feature request at https:
     const popoverPropsHaveAnchor = !!popoverProps?.anchor || // Note: `anchorRef`, `getAnchorRect` and `anchorRect` are deprecated and
     // be removed from `Popover` from WordPress 6.3
     !!popoverProps?.anchorRef || !!popoverProps?.getAnchorRect || !!popoverProps?.anchorRect;
-    return /* @__PURE__ */ (0, import_jsx_runtime47.jsxs)("div", {
+    return /* @__PURE__ */ (0, import_jsx_runtime48.jsxs)("div", {
       className,
       ref: useMergeRefs([containerRef, forwardedRef, setFallbackPopoverAnchor]),
       tabIndex: -1,
       style,
-      children: [renderToggle(args), isOpen && /* @__PURE__ */ (0, import_jsx_runtime47.jsx)(popover_default, {
+      children: [renderToggle(args), isOpen && /* @__PURE__ */ (0, import_jsx_runtime48.jsx)(popover_default, {
         position: position2,
         onClose: close2,
         onFocusOutside: closeIfFocusOutside,
@@ -52062,10 +52073,10 @@ If there's a particular need for this, please submit a feature request at https:
   }
 
   // node_modules/@wordpress/components/build-module/elevation/component.js
-  var import_jsx_runtime48 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime49 = __toESM(require_jsx_runtime());
   function UnconnectedElevation(props, forwardedRef) {
     const elevationProps = useElevation(props);
-    return /* @__PURE__ */ (0, import_jsx_runtime48.jsx)(component_default, {
+    return /* @__PURE__ */ (0, import_jsx_runtime49.jsx)(component_default, {
       ...elevationProps,
       ref: forwardedRef
     });
@@ -52252,7 +52263,7 @@ If there's a particular need for this, please submit a feature request at https:
   }
 
   // node_modules/@wordpress/components/build-module/card/card/component.js
-  var import_jsx_runtime49 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime50 = __toESM(require_jsx_runtime());
   function UnconnectedCard(props, forwardedRef) {
     const {
       children,
@@ -52278,19 +52289,19 @@ If there's a particular need for this, please submit a feature request at https:
         CardFooter: contextProps
       };
     }, [isBorderless, size4]);
-    return /* @__PURE__ */ (0, import_jsx_runtime49.jsx)(ContextSystemProvider, {
+    return /* @__PURE__ */ (0, import_jsx_runtime50.jsx)(ContextSystemProvider, {
       value: contextProviderValue,
-      children: /* @__PURE__ */ (0, import_jsx_runtime49.jsxs)(component_default, {
+      children: /* @__PURE__ */ (0, import_jsx_runtime50.jsxs)(component_default, {
         ...otherProps,
         ref: forwardedRef,
-        children: [/* @__PURE__ */ (0, import_jsx_runtime49.jsx)(component_default, {
+        children: [/* @__PURE__ */ (0, import_jsx_runtime50.jsx)(component_default, {
           className: cx3(Content),
           children
-        }), /* @__PURE__ */ (0, import_jsx_runtime49.jsx)(component_default5, {
+        }), /* @__PURE__ */ (0, import_jsx_runtime50.jsx)(component_default5, {
           className: elevationClassName,
           isInteractive: false,
           value: elevation ? 1 : 0
-        }), /* @__PURE__ */ (0, import_jsx_runtime49.jsx)(component_default5, {
+        }), /* @__PURE__ */ (0, import_jsx_runtime50.jsx)(component_default5, {
           className: elevationClassName,
           isInteractive: false,
           value: elevation
@@ -52369,10 +52380,10 @@ If there's a particular need for this, please submit a feature request at https:
   }
 
   // node_modules/@wordpress/components/build-module/scrollable/component.js
-  var import_jsx_runtime50 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime51 = __toESM(require_jsx_runtime());
   function UnconnectedScrollable(props, forwardedRef) {
     const scrollableProps = useScrollable(props);
-    return /* @__PURE__ */ (0, import_jsx_runtime50.jsx)(component_default, {
+    return /* @__PURE__ */ (0, import_jsx_runtime51.jsx)(component_default, {
       ...scrollableProps,
       ref: forwardedRef
     });
@@ -52407,19 +52418,19 @@ If there's a particular need for this, please submit a feature request at https:
   }
 
   // node_modules/@wordpress/components/build-module/card/card-body/component.js
-  var import_jsx_runtime51 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime52 = __toESM(require_jsx_runtime());
   function UnconnectedCardBody(props, forwardedRef) {
     const {
       isScrollable,
       ...otherProps
     } = useCardBody(props);
     if (isScrollable) {
-      return /* @__PURE__ */ (0, import_jsx_runtime51.jsx)(component_default7, {
+      return /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(component_default7, {
         ...otherProps,
         ref: forwardedRef
       });
     }
-    return /* @__PURE__ */ (0, import_jsx_runtime51.jsx)(component_default, {
+    return /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(component_default, {
       ...otherProps,
       ref: forwardedRef
     });
@@ -52428,7 +52439,7 @@ If there's a particular need for this, please submit a feature request at https:
   var component_default8 = CardBody;
 
   // node_modules/@wordpress/components/build-module/navigable-container/container.js
-  var import_jsx_runtime52 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime53 = __toESM(require_jsx_runtime());
   var noop5 = () => {
   };
   var MENU_ITEM_ROLES = ["menuitem", "menuitemradio", "menuitemcheckbox"];
@@ -52552,7 +52563,7 @@ If there's a particular need for this, please submit a feature request at https:
         forwardedRef,
         ...restProps
       } = this.props;
-      return /* @__PURE__ */ (0, import_jsx_runtime52.jsx)("div", {
+      return /* @__PURE__ */ (0, import_jsx_runtime53.jsx)("div", {
         ref: this.bindContainer,
         ...restProps,
         children
@@ -52560,7 +52571,7 @@ If there's a particular need for this, please submit a feature request at https:
     }
   };
   var forwardedNavigableContainer = (props, ref) => {
-    return /* @__PURE__ */ (0, import_jsx_runtime52.jsx)(NavigableContainer, {
+    return /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(NavigableContainer, {
       ...props,
       forwardedRef: ref
     });
@@ -52569,7 +52580,7 @@ If there's a particular need for this, please submit a feature request at https:
   var container_default = (0, import_react.forwardRef)(forwardedNavigableContainer);
 
   // node_modules/@wordpress/components/build-module/navigable-container/menu.js
-  var import_jsx_runtime53 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime54 = __toESM(require_jsx_runtime());
   function UnforwardedNavigableMenu({
     role = "menu",
     orientation = "vertical",
@@ -52598,7 +52609,7 @@ If there's a particular need for this, please submit a feature request at https:
       }
       return void 0;
     };
-    return /* @__PURE__ */ (0, import_jsx_runtime53.jsx)(container_default, {
+    return /* @__PURE__ */ (0, import_jsx_runtime54.jsx)(container_default, {
       ref,
       stopNavigationEvents: true,
       onlyBrowserTabstops: false,
@@ -52612,7 +52623,7 @@ If there's a particular need for this, please submit a feature request at https:
   var menu_default2 = NavigableMenu;
 
   // node_modules/@wordpress/components/build-module/dropdown-menu/index.js
-  var import_jsx_runtime54 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime55 = __toESM(require_jsx_runtime());
   function mergeProps2(defaultProps = {}, props = {}) {
     const mergedProps = {
       ...defaultProps,
@@ -52659,7 +52670,7 @@ If there's a particular need for this, please submit a feature request at https:
       className: "components-dropdown-menu__popover",
       variant
     }, popoverProps);
-    return /* @__PURE__ */ (0, import_jsx_runtime54.jsx)(dropdown_default, {
+    return /* @__PURE__ */ (0, import_jsx_runtime55.jsx)(dropdown_default, {
       className,
       popoverProps: mergedPopoverProps,
       renderToggle: ({
@@ -52685,7 +52696,7 @@ If there's a particular need for this, please submit a feature request at https:
             "is-opened": isOpen
           })
         }, restToggleProps);
-        return /* @__PURE__ */ (0, import_jsx_runtime54.jsx)(Toggle, {
+        return /* @__PURE__ */ (0, import_jsx_runtime55.jsx)(Toggle, {
           ...mergedToggleProps,
           icon,
           onClick: (event) => {
@@ -52715,10 +52726,10 @@ If there's a particular need for this, please submit a feature request at https:
             "no-icons": noIcons
           })
         }, menuProps);
-        return /* @__PURE__ */ (0, import_jsx_runtime54.jsxs)(menu_default2, {
+        return /* @__PURE__ */ (0, import_jsx_runtime55.jsxs)(menu_default2, {
           ...mergedMenuProps,
           role: "menu",
-          children: [isFunction2(children) ? children(props) : null, controlSets?.flatMap((controlSet, indexOfSet) => controlSet.map((control, indexOfControl) => /* @__PURE__ */ (0, import_jsx_runtime54.jsx)(button_default, {
+          children: [isFunction2(children) ? children(props) : null, controlSets?.flatMap((controlSet, indexOfSet) => controlSet.map((control, indexOfControl) => /* @__PURE__ */ (0, import_jsx_runtime55.jsx)(button_default, {
             onClick: (event) => {
               event.stopPropagation();
               props.onClose();
@@ -52837,7 +52848,7 @@ If there's a particular need for this, please submit a feature request at https:
   }
 
   // node_modules/@wordpress/components/build-module/modal/index.js
-  var import_jsx_runtime55 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime56 = __toESM(require_jsx_runtime());
   var ModalContext = (0, import_react.createContext)(/* @__PURE__ */ new Set());
   var bodyOpenClasses = /* @__PURE__ */ new Map();
   function UnforwardedModal(props, forwardedRef) {
@@ -52994,14 +53005,14 @@ If there's a particular need for this, please submit a feature request at https:
     };
     const modal = (
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-      /* @__PURE__ */ (0, import_jsx_runtime55.jsx)("div", {
+      /* @__PURE__ */ (0, import_jsx_runtime56.jsx)("div", {
         ref: useMergeRefs([ref, forwardedRef]),
         className: clsx_default("components-modal__screen-overlay", overlayClassname, overlayClassnameProp),
         onKeyDown: withIgnoreIMEEvents(handleEscapeKeyDown),
         ...shouldCloseOnClickOutside ? overlayPressHandlers : {},
-        children: /* @__PURE__ */ (0, import_jsx_runtime55.jsx)(style_provider_default, {
+        children: /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(style_provider_default, {
           document,
-          children: /* @__PURE__ */ (0, import_jsx_runtime55.jsx)("div", {
+          children: /* @__PURE__ */ (0, import_jsx_runtime56.jsx)("div", {
             className: clsx_default("components-modal__frame", sizeClass, className),
             style: {
               ...frameStyle,
@@ -53014,7 +53025,7 @@ If there's a particular need for this, please submit a feature request at https:
             "aria-describedby": aria.describedby,
             tabIndex: -1,
             onKeyDown,
-            children: /* @__PURE__ */ (0, import_jsx_runtime55.jsxs)("div", {
+            children: /* @__PURE__ */ (0, import_jsx_runtime56.jsxs)("div", {
               className: clsx_default("components-modal__content", {
                 "hide-header": __experimentalHideHeader,
                 "is-scrollable": hasScrollableContent,
@@ -53025,31 +53036,31 @@ If there's a particular need for this, please submit a feature request at https:
               ref: contentRef,
               "aria-label": hasScrollableContent ? __("Scrollable section") : void 0,
               tabIndex: hasScrollableContent ? 0 : void 0,
-              children: [!__experimentalHideHeader && /* @__PURE__ */ (0, import_jsx_runtime55.jsxs)("div", {
+              children: [!__experimentalHideHeader && /* @__PURE__ */ (0, import_jsx_runtime56.jsxs)("div", {
                 className: "components-modal__header",
-                children: [/* @__PURE__ */ (0, import_jsx_runtime55.jsxs)("div", {
+                children: [/* @__PURE__ */ (0, import_jsx_runtime56.jsxs)("div", {
                   className: "components-modal__header-heading-container",
-                  children: [icon && /* @__PURE__ */ (0, import_jsx_runtime55.jsx)("span", {
+                  children: [icon && /* @__PURE__ */ (0, import_jsx_runtime56.jsx)("span", {
                     className: "components-modal__icon-container",
                     "aria-hidden": true,
                     children: icon
-                  }), title && /* @__PURE__ */ (0, import_jsx_runtime55.jsx)("h1", {
+                  }), title && /* @__PURE__ */ (0, import_jsx_runtime56.jsx)("h1", {
                     id: headingId,
                     className: "components-modal__header-heading",
                     children: title
                   })]
-                }), headerActions, isDismissible && /* @__PURE__ */ (0, import_jsx_runtime55.jsxs)(import_jsx_runtime55.Fragment, {
-                  children: [/* @__PURE__ */ (0, import_jsx_runtime55.jsx)(component_default4, {
+                }), headerActions, isDismissible && /* @__PURE__ */ (0, import_jsx_runtime56.jsxs)(import_jsx_runtime56.Fragment, {
+                  children: [/* @__PURE__ */ (0, import_jsx_runtime56.jsx)(component_default4, {
                     marginBottom: 0,
                     marginLeft: 2
-                  }), /* @__PURE__ */ (0, import_jsx_runtime55.jsx)(button_default, {
+                  }), /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(button_default, {
                     size: "compact",
                     onClick: (event) => closeModal().then(() => onRequestClose(event)),
                     icon: close_default,
                     label: closeButtonLabel || __("Close")
                   })]
                 })]
-              }), /* @__PURE__ */ (0, import_jsx_runtime55.jsx)("div", {
+              }), /* @__PURE__ */ (0, import_jsx_runtime56.jsx)("div", {
                 ref: useMergeRefs([childrenContainerRef, focusOnMount === "firstContentElement" ? focusOnMountRef : null]),
                 children
               })]
@@ -53058,7 +53069,7 @@ If there's a particular need for this, please submit a feature request at https:
         })
       })
     );
-    return (0, import_react_dom.createPortal)(/* @__PURE__ */ (0, import_jsx_runtime55.jsx)(ModalContext.Provider, {
+    return (0, import_react_dom.createPortal)(/* @__PURE__ */ (0, import_jsx_runtime56.jsx)(ModalContext.Provider, {
       value: nestedDismissers,
       children: modal
     }), document.body);
@@ -53107,12 +53118,12 @@ If there's a particular need for this, please submit a feature request at https:
   })(commonPathProps, ";stroke:currentColor;stroke-linecap:round;transform-origin:50% 50%;animation:1.4s linear infinite both ", spinAnimation, ";" + (false ? "" : "/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIkB3b3JkcHJlc3MvY29tcG9uZW50cy9zcmMvc3Bpbm5lci9zdHlsZXMudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBMEMyQyIsImZpbGUiOiJAd29yZHByZXNzL2NvbXBvbmVudHMvc3JjL3NwaW5uZXIvc3R5bGVzLnRzIiwic291cmNlc0NvbnRlbnQiOlsiLyoqXG4gKiBFeHRlcm5hbCBkZXBlbmRlbmNpZXNcbiAqL1xuaW1wb3J0IHN0eWxlZCBmcm9tICdAZW1vdGlvbi9zdHlsZWQnO1xuaW1wb3J0IHsgY3NzLCBrZXlmcmFtZXMgfSBmcm9tICdAZW1vdGlvbi9yZWFjdCc7XG5cbi8qKlxuICogSW50ZXJuYWwgZGVwZW5kZW5jaWVzXG4gKi9cbmltcG9ydCB7IENPTE9SUywgQ09ORklHIH0gZnJvbSAnLi4vdXRpbHMnO1xuXG5jb25zdCBzcGluQW5pbWF0aW9uID0ga2V5ZnJhbWVzYFxuXHRmcm9tIHtcblx0XHR0cmFuc2Zvcm06IHJvdGF0ZSgwZGVnKTtcblx0fVxuXHR0byB7XG5cdFx0dHJhbnNmb3JtOiByb3RhdGUoMzYwZGVnKTtcblx0fVxuIGA7XG5cbmV4cG9ydCBjb25zdCBTdHlsZWRTcGlubmVyID0gc3R5bGVkLnN2Z2Bcblx0d2lkdGg6ICR7IENPTkZJRy5zcGlubmVyU2l6ZSB9cHg7XG5cdGhlaWdodDogJHsgQ09ORklHLnNwaW5uZXJTaXplIH1weDtcblx0ZGlzcGxheTogaW5saW5lLWJsb2NrO1xuXHRtYXJnaW46IDVweCAxMXB4IDA7XG5cdHBvc2l0aW9uOiByZWxhdGl2ZTtcblx0Y29sb3I6ICR7IENPTE9SUy50aGVtZS5hY2NlbnQgfTtcblx0b3ZlcmZsb3c6IHZpc2libGU7XG5cdG9wYWNpdHk6IDE7XG5cdGJhY2tncm91bmQtY29sb3I6IHRyYW5zcGFyZW50O1xuYDtcblxuY29uc3QgY29tbW9uUGF0aFByb3BzID0gY3NzYFxuXHRmaWxsOiB0cmFuc3BhcmVudDtcblx0c3Ryb2tlLXdpZHRoOiAxLjVweDtcbmA7XG5cbmV4cG9ydCBjb25zdCBTcGlubmVyVHJhY2sgPSBzdHlsZWQuY2lyY2xlYFxuXHQkeyBjb21tb25QYXRoUHJvcHMgfTtcblx0c3Ryb2tlOiAkeyBDT0xPUlMuZ3JheVsgMzAwIF0gfTtcbmA7XG5cbmV4cG9ydCBjb25zdCBTcGlubmVySW5kaWNhdG9yID0gc3R5bGVkLnBhdGhgXG5cdCR7IGNvbW1vblBhdGhQcm9wcyB9O1xuXHRzdHJva2U6IGN1cnJlbnRDb2xvcjtcblx0c3Ryb2tlLWxpbmVjYXA6IHJvdW5kO1xuXHR0cmFuc2Zvcm0tb3JpZ2luOiA1MCUgNTAlO1xuXHRhbmltYXRpb246IDEuNHMgbGluZWFyIGluZmluaXRlIGJvdGggJHsgc3BpbkFuaW1hdGlvbiB9O1xuYDtcbiJdfQ== */"));
 
   // node_modules/@wordpress/components/build-module/spinner/index.js
-  var import_jsx_runtime56 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime57 = __toESM(require_jsx_runtime());
   function UnforwardedSpinner({
     className,
     ...props
   }, forwardedRef) {
-    return /* @__PURE__ */ (0, import_jsx_runtime56.jsxs)(StyledSpinner, {
+    return /* @__PURE__ */ (0, import_jsx_runtime57.jsxs)(StyledSpinner, {
       className: clsx_default("components-spinner", className),
       viewBox: "0 0 100 100",
       width: "16",
@@ -53122,12 +53133,12 @@ If there's a particular need for this, please submit a feature request at https:
       focusable: "false",
       ...props,
       ref: forwardedRef,
-      children: [/* @__PURE__ */ (0, import_jsx_runtime56.jsx)(SpinnerTrack, {
+      children: [/* @__PURE__ */ (0, import_jsx_runtime57.jsx)(SpinnerTrack, {
         cx: "50",
         cy: "50",
         r: "50",
         vectorEffect: "non-scaling-stroke"
-      }), /* @__PURE__ */ (0, import_jsx_runtime56.jsx)(SpinnerIndicator, {
+      }), /* @__PURE__ */ (0, import_jsx_runtime57.jsx)(SpinnerIndicator, {
         d: "m 50 0 a 50 50 0 0 1 50 50",
         vectorEffect: "non-scaling-stroke"
       })]
@@ -53137,7 +53148,7 @@ If there's a particular need for this, please submit a feature request at https:
   var spinner_default = Spinner;
 
   // node_modules/@wordpress/components/build-module/tab-panel/index.js
-  var import_jsx_runtime57 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime58 = __toESM(require_jsx_runtime());
   var extractTabName = (id3) => {
     if (typeof id3 === "undefined" || id3 === null) {
       return;
@@ -53220,21 +53231,21 @@ If there's a particular need for this, please submit a feature request at https:
         setTabStoreSelectedId(firstEnabledTab.name);
       }
     }, [tabs, selectedTab?.disabled, setTabStoreSelectedId, instanceId]);
-    return /* @__PURE__ */ (0, import_jsx_runtime57.jsxs)("div", {
+    return /* @__PURE__ */ (0, import_jsx_runtime58.jsxs)("div", {
       className,
       ref,
-      children: [/* @__PURE__ */ (0, import_jsx_runtime57.jsx)(TabList, {
+      children: [/* @__PURE__ */ (0, import_jsx_runtime58.jsx)(TabList, {
         store: tabStore,
         className: "components-tab-panel__tabs",
         children: tabs.map((tab) => {
-          return /* @__PURE__ */ (0, import_jsx_runtime57.jsx)(Tab, {
+          return /* @__PURE__ */ (0, import_jsx_runtime58.jsx)(Tab, {
             id: prependInstanceId(tab.name),
             className: clsx_default("components-tab-panel__tabs-item", tab.className, {
               [activeClass]: tab.name === selectedTabName
             }),
             disabled: tab.disabled,
             "aria-controls": `${prependInstanceId(tab.name)}-view`,
-            render: /* @__PURE__ */ (0, import_jsx_runtime57.jsx)(button_default, {
+            render: /* @__PURE__ */ (0, import_jsx_runtime58.jsx)(button_default, {
               __next40pxDefaultSize: true,
               icon: tab.icon,
               label: tab.icon && tab.title,
@@ -53243,7 +53254,7 @@ If there's a particular need for this, please submit a feature request at https:
             children: !tab.icon && tab.title
           }, tab.name);
         })
-      }), selectedTab && /* @__PURE__ */ (0, import_jsx_runtime57.jsx)(TabPanel, {
+      }), selectedTab && /* @__PURE__ */ (0, import_jsx_runtime58.jsx)(TabPanel, {
         id: `${prependInstanceId(selectedTab.name)}-view`,
         store: tabStore,
         tabId: prependInstanceId(selectedTab.name),
@@ -53256,7 +53267,7 @@ If there's a particular need for this, please submit a feature request at https:
   var tab_panel_default = TabPanel3;
 
   // node_modules/@wordpress/components/build-module/text-control/index.js
-  var import_jsx_runtime58 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime59 = __toESM(require_jsx_runtime());
   function UnforwardedTextControl(props, ref) {
     const {
       __nextHasNoMarginBottom,
@@ -53278,7 +53289,7 @@ If there's a particular need for this, please submit a feature request at https:
       size: void 0,
       __next40pxDefaultSize
     });
-    return /* @__PURE__ */ (0, import_jsx_runtime58.jsx)(base_control_default, {
+    return /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(base_control_default, {
       __nextHasNoMarginBottom,
       __associatedWPComponentName: "TextControl",
       label,
@@ -53286,7 +53297,7 @@ If there's a particular need for this, please submit a feature request at https:
       id: id3,
       help,
       className,
-      children: /* @__PURE__ */ (0, import_jsx_runtime58.jsx)("input", {
+      children: /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("input", {
         className: clsx_default("components-text-control__input", {
           "is-next-40px-default-size": __next40pxDefaultSize
         }),
@@ -53305,7 +53316,7 @@ If there's a particular need for this, please submit a feature request at https:
 
   // src/renderer/index.jsx
   var import_xterm = __toESM(require_xterm());
-  var import_jsx_runtime59 = __toESM(require_jsx_runtime());
+  var import_jsx_runtime60 = __toESM(require_jsx_runtime());
   var TERMINAL_ALLOWED_SCRIPTS = ["build", "build:dev", "dev", "test", "watch", "grunt"];
   var TERMINAL_INSTALL_ALIASES = ["npm install", "npm i", "install"];
   var RENAME_INPUT_ID = "rename-site-name-input";
@@ -53705,11 +53716,11 @@ If there's a particular need for this, please submit a feature request at https:
     const handleSelectSite = (0, import_react69.useCallback)((sitePath) => {
       setActiveSite(sitePath);
     }, []);
-    return /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { display: "flex", height: "100vh", fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif" }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { width: sidebarCollapsed ? 56 : 280, background: "#1f1f1f", color: "#f7f7f7", display: "flex", flexDirection: "column", transition: "width 0.2s ease", borderRight: "1px solid #2b2b2b" }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { padding: sidebarCollapsed ? "12px 8px" : "16px", borderBottom: "1px solid #2b2b2b" }, children: /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)(component_default3, { align: "center", justify: "space-between", children: [
-          !sidebarCollapsed ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { fontWeight: 600 }, children: "WordPress Core" }) : null,
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { display: "flex", height: "100vh", fontFamily: "-apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif" }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { width: sidebarCollapsed ? 56 : 280, background: "#1f1f1f", color: "#f7f7f7", display: "flex", flexDirection: "column", transition: "width 0.2s ease", borderRight: "1px solid #2b2b2b" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { padding: sidebarCollapsed ? "12px 8px" : "16px", borderBottom: "1px solid #2b2b2b" }, children: /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)(component_default3, { align: "center", justify: "space-between", children: [
+          !sidebarCollapsed ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { fontWeight: 600 }, children: "WordPress Core" }) : null,
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
             button_default,
             {
               icon: sidebarCollapsed ? chevron_right_default : chevron_left_default,
@@ -53722,13 +53733,13 @@ If there's a particular need for this, please submit a feature request at https:
             }
           )
         ] }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { flex: 1, overflowY: "auto", padding: sidebarCollapsed ? "12px 8px" : "12px 16px", display: "flex", flexDirection: "column", gap: 8 }, children: sortedSites.length > 0 ? sortedSites.map((sitePath) => {
+        /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { flex: 1, overflowY: "auto", padding: sidebarCollapsed ? "12px 8px" : "12px 16px", display: "flex", flexDirection: "column", gap: 8 }, children: sortedSites.length > 0 ? sortedSites.map((sitePath) => {
           const meta = siteMeta?.[sitePath] || {};
           const siteName = meta.label && meta.label.trim() || sitePath.split("/").pop() || sitePath;
           const createdLabel = meta.createdAt ? new Date(meta.createdAt).toLocaleString() : "";
           const isActive = activeSite === sitePath;
           const statusLabel = meta.initialized ? "Initialized" : "Not initialized";
-          return /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+          return /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
             button_default,
             {
               onClick: () => handleSelectSite(sitePath),
@@ -53744,19 +53755,19 @@ If there's a particular need for this, please submit a feature request at https:
                 padding: sidebarCollapsed ? "8px 0" : "10px 12px",
                 borderRadius: 6
               },
-              children: sidebarCollapsed ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("span", { style: { fontWeight: 600 }, children: siteName.slice(0, 1).toUpperCase() }) : /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 2 }, children: /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("span", { style: { fontWeight: 600 }, children: siteName }) })
+              children: sidebarCollapsed ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("span", { style: { fontWeight: 600 }, children: siteName.slice(0, 1).toUpperCase() }) : /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 2 }, children: /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("span", { style: { fontWeight: 600 }, children: siteName }) })
             },
             sitePath
           );
-        }) : !sidebarCollapsed ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { fontSize: 12, color: "rgba(255,255,255,0.7)" }, children: "No sites yet." }) : null }),
-        /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+        }) : !sidebarCollapsed ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { fontSize: 12, color: "rgba(255,255,255,0.7)" }, children: "No sites yet." }) : null }),
+        /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
           "div",
           {
             style: {
               padding: sidebarCollapsed ? "12px 8px 20px" : "16px 16px 24px",
               borderTop: "1px solid #2b2b2b"
             },
-            children: /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+            children: /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
               button_default,
               {
                 icon: plus_default,
@@ -53770,9 +53781,9 @@ If there's a particular need for this, please submit a feature request at https:
           }
         )
       ] }),
-      /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { flex: 1, background: "#fff", color: "#1d2327", display: "flex", flexDirection: "column" }, children: /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { flex: 1, overflowY: "auto", padding: "32px 32px 48px" }, children: /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { maxWidth: 1040, margin: "0 auto" }, children: [
-        webAvailable ? /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)(component_default3, { align: "center", justify: "flex-end", style: { gap: 8, marginBottom: 24 }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { flex: 1, background: "#fff", color: "#1d2327", display: "flex", flexDirection: "column" }, children: /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { flex: 1, overflowY: "auto", padding: "32px 32px 48px" }, children: /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { maxWidth: 1040, margin: "0 auto" }, children: [
+        webAvailable ? /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)(component_default3, { align: "center", justify: "flex-end", style: { gap: 8, marginBottom: 24 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
             button_default,
             {
               isBusy: webStarting,
@@ -53781,34 +53792,34 @@ If there's a particular need for this, please submit a feature request at https:
               children: webUrl ? "Stop Playground web server" : "Start Playground web server"
             }
           ),
-          webStarting || webUrl ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("span", { style: { fontSize: 12 }, children: webStarting ? "Starting\u2026" : /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("a", { href: webUrl || "http://127.0.0.1:39372/", onClick: (e) => {
+          webStarting || webUrl ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("span", { style: { fontSize: 12 }, children: webStarting ? "Starting\u2026" : /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("a", { href: webUrl || "http://127.0.0.1:39372/", onClick: (e) => {
             e.preventDefault();
             window.api.openExternal(webUrl || "http://127.0.0.1:39372/");
           }, children: webUrl || "http://127.0.0.1:39372/" }) }) : null
         ] }) : null,
-        webStarting || webUrl || webError || webLogs ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(component_default6, { style: { marginBottom: 24 }, children: /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)(component_default8, { children: [
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, justifyContent: "space-between" }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { fontWeight: 600 }, children: "Playground web server" }),
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { fontSize: 12, color: "#666" }, children: webStarting ? "Starting\u2026" : webUrl ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("a", { href: webUrl, onClick: (e) => {
+        webStarting || webUrl || webError || webLogs ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(component_default6, { style: { marginBottom: 24 }, children: /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)(component_default8, { children: [
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, justifyContent: "space-between" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { fontWeight: 600 }, children: "Playground web server" }),
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { fontSize: 12, color: "#666" }, children: webStarting ? "Starting\u2026" : webUrl ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("a", { href: webUrl, onClick: (e) => {
               e.preventDefault();
               window.api.openExternal(webUrl);
             }, children: webUrl }) : "Stopped" })
           ] }),
-          webError ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { marginTop: 6, color: "#C00", fontSize: 12 }, children: webError }) : null,
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { ref: webLogRef, style: { marginTop: 8, whiteSpace: "pre-wrap", background: "#111", color: "#eee", padding: 8, borderRadius: 6, height: 140, overflow: "auto" }, children: webLogs })
+          webError ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { marginTop: 6, color: "#C00", fontSize: 12 }, children: webError }) : null,
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { ref: webLogRef, style: { marginTop: 8, whiteSpace: "pre-wrap", background: "#111", color: "#eee", padding: 8, borderRadius: 6, height: 140, overflow: "auto" }, children: webLogs })
         ] }) }) : null,
-        /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { id: "sites", children: [
-          pendingSite && /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(component_default6, { style: { marginBottom: 24 }, children: /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)(component_default8, { children: [
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { fontWeight: 600 }, children: "Setting up new site\u2026" }),
-            downloadPhase && /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { fontSize: 12, color: "#555", marginBottom: 6 }, children: downloadPhase }),
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { ref: termRef, style: { whiteSpace: "pre-wrap", background: "#111", color: "#eee", padding: 8, borderRadius: 6, height: 140, overflow: "auto" }, children: terminalMsgs })
+        /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { id: "sites", children: [
+          pendingSite && /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(component_default6, { style: { marginBottom: 24 }, children: /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)(component_default8, { children: [
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { fontWeight: 600 }, children: "Setting up new site\u2026" }),
+            downloadPhase && /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { fontSize: 12, color: "#555", marginBottom: 6 }, children: downloadPhase }),
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { ref: termRef, style: { whiteSpace: "pre-wrap", background: "#111", color: "#eee", padding: 8, borderRadius: 6, height: 140, overflow: "auto" }, children: terminalMsgs })
           ] }) }),
-          sortedSites.length > 0 ? sortedSites.map((s) => /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+          sortedSites.length > 0 ? sortedSites.map((s) => /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
             "div",
             {
               style: { display: activeSite === s ? "block" : "none" },
               "aria-hidden": activeSite === s ? false : true,
-              children: /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+              children: /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
                 SiteRow,
                 {
                   sitePath: s,
@@ -53825,27 +53836,27 @@ If there's a particular need for this, please submit a feature request at https:
               )
             },
             s
-          )) : /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(component_default6, { children: /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)(component_default8, { children: [
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { marginBottom: 8 }, children: "No sites yet." }),
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { children: "Use the sidebar to create your first site." })
+          )) : /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(component_default6, { children: /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)(component_default8, { children: [
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { marginBottom: 8 }, children: "No sites yet." }),
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { children: "Use the sidebar to create your first site." })
           ] }) })
         ] })
       ] }) }) }),
-      createModalOpen ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+      createModalOpen ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
         modal_default,
         {
           className: "create-site-modal",
           title: "Create WordPress Core site",
           onRequestClose: closeCreateModal,
           shouldCloseOnClickOutside: !createSubmitting,
-          children: /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)(
+          children: /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)(
             "form",
             {
               onSubmit: handleCreateModalSubmit,
               onKeyDown: handleCreateModalKeyDown,
               style: { display: "flex", flexDirection: "column", gap: 16, color: "#1d2327", colorScheme: "light" },
               children: [
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
                   text_control_default,
                   {
                     id: CREATE_SITE_NAME_INPUT_ID,
@@ -53857,9 +53868,9 @@ If there's a particular need for this, please submit a feature request at https:
                     autoFocus: true
                   }
                 ),
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("label", { htmlFor: CREATE_SITE_LOCATION_INPUT_ID, style: { fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.02em", color: "#1d2327" }, children: "Site location" }),
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }, children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("label", { htmlFor: CREATE_SITE_LOCATION_INPUT_ID, style: { fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.02em", color: "#1d2327" }, children: "Site location" }),
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }, children: [
+                  /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
                     "input",
                     {
                       ref: createDirInputRef,
@@ -53881,13 +53892,13 @@ If there's a particular need for this, please submit a feature request at https:
                       style: { height: 40, color: "#1d2327", background: "#fff", border: "1px solid #8c8f94", borderRadius: 4, padding: "6px 10px" }
                     }
                   ),
-                  /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("span", { style: { fontSize: 12, color: "#3c434a" }, children: createSiteDir || "No folder selected yet." })
+                  /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("span", { style: { fontSize: 12, color: "#3c434a" }, children: createSiteDir || "No folder selected yet." })
                 ] }),
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { id: CREATE_SITE_LOCATION_HELP_ID, style: { fontSize: 12, color: "#3c434a", marginTop: -4 }, children: "Choose the parent folder where you want this new site created. We'll add a new directory inside it for the project." }),
-                createSiteError ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { color: "#d63638", fontSize: 12 }, children: createSiteError }) : null,
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { display: "flex", justifyContent: "flex-end", gap: 8 }, children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(button_default, { type: "button", variant: "secondary", onClick: closeCreateModal, disabled: createSubmitting, children: "Cancel" }),
-                  /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(button_default, { type: "submit", variant: "primary", isBusy: createSubmitting, disabled: createSubmitting, children: "Create site" })
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { id: CREATE_SITE_LOCATION_HELP_ID, style: { fontSize: 12, color: "#3c434a", marginTop: -4 }, children: "Choose the parent folder where you want this new site created. We'll add a new directory inside it for the project." }),
+                createSiteError ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { color: "#d63638", fontSize: 12 }, children: createSiteError }) : null,
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { display: "flex", justifyContent: "flex-end", gap: 8 }, children: [
+                  /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(button_default, { type: "button", variant: "secondary", onClick: closeCreateModal, disabled: createSubmitting, children: "Cancel" }),
+                  /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(button_default, { type: "submit", variant: "primary", isBusy: createSubmitting, disabled: createSubmitting, children: "Create site" })
                 ] })
               ]
             }
@@ -54613,7 +54624,7 @@ Try "help" for the list of supported commands.
         description: "Install npm packages so commands can run.",
         done: hasNodeModules,
         ready: true,
-        action: /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+        action: /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
           button_default,
           {
             isBusy: installing,
@@ -54630,7 +54641,7 @@ Try "help" for the list of supported commands.
         description: "Compile WordPress Core once to generate the initial dist files.",
         done: hasBuilt,
         ready: hasNodeModules,
-        action: /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+        action: /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
           button_default,
           {
             isBusy: building,
@@ -54647,8 +54658,8 @@ Try "help" for the list of supported commands.
         description: "Launch the development server once to complete the WordPress setup wizard.",
         done: false,
         ready: hasBuilt,
-        action: /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8 }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+        action: /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
             button_default,
             {
               isBusy: starting,
@@ -54661,7 +54672,7 @@ Try "help" for the list of supported commands.
               children: running ? "Stop dev server" : "Start dev server and finish the wizard"
             }
           ),
-          starting || serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("span", { style: { fontSize: 12 }, children: starting ? "Starting..." : serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("a", { href: serverUrl, onClick: (e) => {
+          starting || serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("span", { style: { fontSize: 12 }, children: starting ? "Starting..." : serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("a", { href: serverUrl, onClick: (e) => {
             e.preventDefault();
             window.api.openExternal(serverUrl);
           }, children: serverUrl }) : null }) : null
@@ -54683,12 +54694,12 @@ Try "help" for the list of supported commands.
       }
       return { ...step, status };
     });
-    return /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("section", { style: { display: "flex", flexDirection: "column", gap: 24, paddingBottom: 48 }, children: [
-      /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)(component_default3, { align: "flex-start", justify: "space-between", style: { gap: 16, flexWrap: "wrap" }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { flex: "1 1 440px", minWidth: 0 }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("h1", { style: { margin: 0, fontSize: 28, lineHeight: 1.2 }, children: displayName }),
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+    return /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("section", { style: { display: "flex", flexDirection: "column", gap: 24, paddingBottom: 48 }, children: [
+      /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)(component_default3, { align: "flex-start", justify: "space-between", style: { gap: 16, flexWrap: "wrap" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { flex: "1 1 440px", minWidth: 0 }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("h1", { style: { margin: 0, fontSize: 28, lineHeight: 1.2 }, children: displayName }),
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
               button_default,
               {
                 icon: edit_default,
@@ -54700,19 +54711,19 @@ Try "help" for the list of supported commands.
               }
             )
           ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, marginTop: 8, fontSize: 12, color: "#3c434a", flexWrap: "wrap" }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("span", { style: { display: "inline-flex", alignItems: "center", padding: "2px 8px", borderRadius: 999, fontSize: 11, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.02em", ...statusStyles }, children: initialized ? "Initialized" : "Uninitialized" }),
-            createdLabel ? /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("span", { children: [
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 8, marginTop: 8, fontSize: 12, color: "#3c434a", flexWrap: "wrap" }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("span", { style: { display: "inline-flex", alignItems: "center", padding: "2px 8px", borderRadius: 999, fontSize: 11, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.02em", ...statusStyles }, children: initialized ? "Initialized" : "Uninitialized" }),
+            createdLabel ? /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("span", { children: [
               "Created ",
               createdLabel
             ] }) : null
           ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 4, marginTop: 6 }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("code", { style: { fontSize: 12, color: "#3c434a", background: "#f0f0f1", padding: "2px 6px", borderRadius: 4, overflowWrap: "anywhere" }, children: sitePath }),
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 4, marginTop: 6 }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("code", { style: { fontSize: 12, color: "#3c434a", background: "#f0f0f1", padding: "2px 6px", borderRadius: 4, overflowWrap: "anywhere" }, children: sitePath }),
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
               button_default,
               {
-                icon: copy_default,
+                icon: pathCopied ? check_default : copy_default,
                 label: pathCopied ? "Copied!" : "Copy path",
                 "aria-label": pathCopied ? "Copied!" : "Copy path",
                 onClick: copyPath,
@@ -54722,7 +54733,7 @@ Try "help" for the list of supported commands.
             )
           ] })
         ] }),
-        /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { display: "flex", alignItems: "flex-start", gap: 8 }, children: /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+        /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { display: "flex", alignItems: "flex-start", gap: 8 }, children: /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
           dropdown_menu_default,
           {
             label: "More",
@@ -54735,12 +54746,12 @@ Try "help" for the list of supported commands.
           }
         ) })
       ] }),
-      !skipInit ? /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { padding: 20, border: "1px solid #dcdcde", borderRadius: 12, background: "#fff" }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { fontWeight: 600, fontSize: 16, color: "#1d2327" }, children: "Initial setup checklist" }),
-        /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { marginTop: 4, fontSize: 13, color: "#3c434a" }, children: "Complete each step to prepare this site for development." }),
-        /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { marginTop: 16, display: "flex", flexDirection: "column", gap: 12 }, children: stepItems.map((step) => {
+      !skipInit ? /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { padding: 20, border: "1px solid #dcdcde", borderRadius: 12, background: "#fff" }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { fontWeight: 600, fontSize: 16, color: "#1d2327" }, children: "Initial setup checklist" }),
+        /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { marginTop: 4, fontSize: 13, color: "#3c434a" }, children: "Complete each step to prepare this site for development." }),
+        /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { marginTop: 16, display: "flex", flexDirection: "column", gap: 12 }, children: stepItems.map((step) => {
           const visuals = checklistVisuals[step.status] || checklistVisuals.locked;
-          return /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)(
+          return /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)(
             "div",
             {
               style: {
@@ -54756,7 +54767,7 @@ Try "help" for the list of supported commands.
                 alignItems: "center"
               },
               children: [
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { gridRow: "1 / span 2", alignSelf: "center", display: "flex", alignItems: "center", justifyContent: "center", width: 28 }, children: /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { gridRow: "1 / span 2", alignSelf: "center", display: "flex", alignItems: "center", justifyContent: "center", width: 28 }, children: /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
                   "span",
                   {
                     style: {
@@ -54776,22 +54787,22 @@ Try "help" for the list of supported commands.
                     children: visuals.indicatorContent
                   }
                 ) }),
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { gridColumn: "2 / 3", display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 12, minWidth: 0, flexWrap: "wrap" }, children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { fontWeight: 600, color: "#1d2327", lineHeight: 1.4 }, children: step.label }),
-                  /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { fontSize: 11, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.04em", color: visuals.color, marginLeft: "auto", whiteSpace: "nowrap" }, children: visuals.label })
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { gridColumn: "2 / 3", display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 12, minWidth: 0, flexWrap: "wrap" }, children: [
+                  /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { fontWeight: 600, color: "#1d2327", lineHeight: 1.4 }, children: step.label }),
+                  /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { fontSize: 11, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.04em", color: visuals.color, marginLeft: "auto", whiteSpace: "nowrap" }, children: visuals.label })
                 ] }),
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { gridColumn: "2 / 3", fontSize: 12, color: "#3c434a", lineHeight: 1.5 }, children: step.description }),
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { gridRow: "1 / span 2", gridColumn: "3 / 4", alignSelf: "center", display: "flex", alignItems: "center" }, children: step.action })
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { gridColumn: "2 / 3", fontSize: 12, color: "#3c434a", lineHeight: 1.5 }, children: step.description }),
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { gridRow: "1 / span 2", gridColumn: "3 / 4", alignSelf: "center", display: "flex", alignItems: "center" }, children: step.action })
               ]
             },
             step.key
           );
         }) }),
-        /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { marginTop: 12 }, children: /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(button_default, { variant: "link", onClick: markSkipWizard, style: { textDecoration: "underline" }, children: "Skip initialization wizard" }) })
+        /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { marginTop: 12 }, children: /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(button_default, { variant: "link", onClick: markSkipWizard, style: { textDecoration: "underline" }, children: "Skip initialization wizard" }) })
       ] }) : null,
-      skipInit ? /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 12 }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { display: "flex", alignItems: "stretch", gap: 12, flexWrap: "wrap" }, children: [
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)(
+      skipInit ? /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 12 }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { display: "flex", alignItems: "stretch", gap: 12, flexWrap: "wrap" }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)(
             button_default,
             {
               isBusy: isServerStarting,
@@ -54799,7 +54810,7 @@ Try "help" for the list of supported commands.
               onClick: toggleDevServer,
               style: { display: "inline-flex", alignItems: "center", gap: 10, minWidth: 220, justifyContent: "center", padding: "12px 20px", fontSize: 15, borderRadius: 12 },
               children: [
-                isDevProcessActive ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+                isDevProcessActive ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
                   "span",
                   {
                     "aria-hidden": "true",
@@ -54814,11 +54825,11 @@ Try "help" for the list of supported commands.
                     }
                   }
                 ) : null,
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("span", { style: { fontWeight: 600 }, children: isDevProcessActive ? isServerStarting ? "Starting dev server..." : "Stop dev server" : "Start dev server" })
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("span", { style: { fontWeight: 600 }, children: isDevProcessActive ? isServerStarting ? "Starting dev server..." : "Stop dev server" : "Start dev server" })
               ]
             }
           ),
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
             button_default,
             {
               variant: "secondary",
@@ -54827,7 +54838,7 @@ Try "help" for the list of supported commands.
               children: "Submit patch"
             }
           ),
-          running && serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+          running && serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
             button_default,
             {
               variant: "secondary",
@@ -54840,24 +54851,24 @@ Try "help" for the list of supported commands.
             }
           ) : null
         ] }),
-        isServerStarting || serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { fontSize: 13, color: "#1d2327", paddingLeft: 2, display: "flex", flexDirection: "column", gap: 4 }, children: serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)(import_jsx_runtime59.Fragment, { children: [
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("a", { href: serverUrl, onClick: (e) => {
+        isServerStarting || serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { fontSize: 13, color: "#1d2327", paddingLeft: 2, display: "flex", flexDirection: "column", gap: 4 }, children: serverUrl ? /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)(import_jsx_runtime60.Fragment, { children: [
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("a", { href: serverUrl, onClick: (e) => {
             e.preventDefault();
             window.api.openExternal(serverUrl);
           }, children: serverUrl }),
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("span", { style: { fontSize: 12, color: "#3c434a" }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("span", { style: { fontSize: 12, color: "#3c434a" }, children: [
             "Log in with ",
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("code", { children: "admin" }),
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("code", { children: "admin" }),
             " / ",
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("code", { children: "admin" }),
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("code", { children: "admin" }),
             "."
           ] })
         ] }) : "Dev server is starting\u2026" }) : null
       ] }) : null,
-      /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 16 }, children: [
-        /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { children: [
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { fontWeight: 600, marginBottom: 8 }, children: "Terminal" }),
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+      /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { display: "flex", flexDirection: "column", gap: 16 }, children: [
+        /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { children: [
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { fontWeight: 600, marginBottom: 8 }, children: "Terminal" }),
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
             "div",
             {
               ref: terminalContainerRef,
@@ -54870,57 +54881,57 @@ Try "help" for the list of supported commands.
               }
             }
           ),
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { marginTop: 8, fontSize: 12, color: "#3c434a" }, children: [
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { marginTop: 8, fontSize: 12, color: "#3c434a" }, children: [
             "Type ",
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("code", { children: "help" }),
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("code", { children: "help" }),
             " to list supported commands. Press ",
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("code", { children: "Ctrl+C" }),
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("code", { children: "Ctrl+C" }),
             " to stop the current command."
           ] })
         ] }),
-        /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { children: [
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { fontWeight: 600, marginBottom: 8 }, children: "Server & WordPress logs" }),
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { ref: runtimeRef, onScroll: makeOnScroll("runtime"), style: { whiteSpace: "pre-wrap", background: "#111", color: "#eee", padding: 12, borderRadius: 6, height: 220, overflow: "auto" }, children: runtimeLogs })
+        /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { children: [
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { fontWeight: 600, marginBottom: 8 }, children: "Server & WordPress logs" }),
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { ref: runtimeRef, onScroll: makeOnScroll("runtime"), style: { whiteSpace: "pre-wrap", background: "#111", color: "#eee", padding: 12, borderRadius: 6, height: 220, overflow: "auto" }, children: runtimeLogs })
         ] }),
-        /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { children: [
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { fontWeight: 600, marginBottom: 8 }, children: "Mail" }),
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { fontSize: 12, color: "#666" }, children: smtpPort ? `SMTP listening on 127.0.0.1:${smtpPort}` : "SMTP will start with the dev server." }),
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { children: /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(button_default, { size: "small", variant: "secondary", onClick: clearEmails, children: "Clear emails" }) })
+        /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { children: [
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { fontWeight: 600, marginBottom: 8 }, children: "Mail" }),
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 8 }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { fontSize: 12, color: "#666" }, children: smtpPort ? `SMTP listening on 127.0.0.1:${smtpPort}` : "SMTP will start with the dev server." }),
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { children: /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(button_default, { size: "small", variant: "secondary", onClick: clearEmails, children: "Clear emails" }) })
           ] }),
-          /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { border: "1px solid #ddd", borderRadius: 6, maxHeight: 220, overflow: "auto" }, children: emails && emails.length ? emails.map((m) => {
+          /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { border: "1px solid #ddd", borderRadius: 6, maxHeight: 220, overflow: "auto" }, children: emails && emails.length ? emails.map((m) => {
             const when = m.sentAt || m.date;
             const whenStr = when ? new Date(when).toLocaleString() : "";
-            return /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)(
+            return /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)(
               "div",
               {
                 onClick: () => openEmail(m),
                 style: { padding: "8px 10px", cursor: "pointer", borderBottom: "1px solid #eee", display: "flex", gap: 8 },
                 children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { flex: "0 0 180px", color: "#555", fontSize: 12 }, children: whenStr }),
-                  /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { flex: "0 0 220px", color: "#333", fontSize: 12, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: m.from || "" }),
-                  /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { flex: "1 1 auto", fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: m.subject || "(no subject)" })
+                  /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { flex: "0 0 180px", color: "#555", fontSize: 12 }, children: whenStr }),
+                  /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { flex: "0 0 220px", color: "#333", fontSize: 12, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: m.from || "" }),
+                  /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { flex: "1 1 auto", fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: m.subject || "(no subject)" })
                 ]
               },
               m.id
             );
-          }) : /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { padding: 12, color: "#666" }, children: "No emails yet." }) })
+          }) : /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { padding: 12, color: "#666" }, children: "No emails yet." }) })
         ] })
       ] }),
-      renameModalOpen ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+      renameModalOpen ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
         modal_default,
         {
           title: "Rename site",
           onRequestClose: closeRenameModal,
           shouldCloseOnClickOutside: !renaming,
-          children: /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)(
+          children: /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)(
             "form",
             {
               onSubmit: handleRenameSubmit,
               onKeyDown: handleRenameFormKeyDown,
               style: { display: "flex", flexDirection: "column", gap: 12 },
               children: [
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
                   text_control_default,
                   {
                     id: RENAME_INPUT_ID,
@@ -54931,17 +54942,17 @@ Try "help" for the list of supported commands.
                     autoFocus: true
                   }
                 ),
-                renameError ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { color: "#d63638", fontSize: 12 }, children: renameError }) : null,
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { display: "flex", justifyContent: "flex-end", gap: 8 }, children: [
-                  /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(button_default, { type: "button", variant: "secondary", onClick: closeRenameModal, disabled: renaming, children: "Cancel" }),
-                  /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(button_default, { type: "submit", variant: "primary", isBusy: renaming, disabled: renaming, children: "Save" })
+                renameError ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { color: "#d63638", fontSize: 12 }, children: renameError }) : null,
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { display: "flex", justifyContent: "flex-end", gap: 8 }, children: [
+                  /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(button_default, { type: "button", variant: "secondary", onClick: closeRenameModal, disabled: renaming, children: "Cancel" }),
+                  /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(button_default, { type: "submit", variant: "primary", isBusy: renaming, disabled: renaming, children: "Save" })
                 ] })
               ]
             }
           )
         }
       ) : null,
-      isPatchOpen && /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+      isPatchOpen && /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
         modal_default,
         {
           title: "Patch",
@@ -54949,21 +54960,21 @@ Try "help" for the list of supported commands.
           shouldCloseOnClickOutside: true,
           isFullScreen: true,
           headerClassName: "patch-modal-header",
-          children: /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { display: "flex", flexDirection: "column", height: "80vh", gap: 12 }, children: [
-            !patchLoading && /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { padding: "12px 16px", background: "#f0f6fc", border: "1px solid #d0d7de", borderRadius: 6, fontSize: 14, lineHeight: 1.5, color: "#24292f" }, children: [
-              /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("strong", { children: "Next steps:" }),
+          children: /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { display: "flex", flexDirection: "column", height: "80vh", gap: 12 }, children: [
+            !patchLoading && /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { padding: "12px 16px", background: "#f0f6fc", border: "1px solid #d0d7de", borderRadius: 6, fontSize: 14, lineHeight: 1.5, color: "#24292f" }, children: [
+              /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("strong", { children: "Next steps:" }),
               " Save this patch and submit it to the relevant WordPress Trac ticket at ",
-              /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("a", { href: "#", onClick: (e) => {
+              /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("a", { href: "#", onClick: (e) => {
                 e.preventDefault();
                 window.api.openExternal("https://core.trac.wordpress.org");
               }, style: { color: "#0969da", cursor: "pointer" }, children: "core.trac.wordpress.org" })
             ] }),
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { position: "relative", flex: 1, minHeight: 0 }, children: patchLoading ? /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", height: "100%", gap: 16 }, children: [
-              /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(spinner_default, {}),
-              /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { color: "#666", fontSize: 14 }, children: "Generating patch..." })
-            ] }) : /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)(import_jsx_runtime59.Fragment, { children: [
-              /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { position: "absolute", top: 8, right: 8, zIndex: 2, display: "flex", gap: 8 }, children: [
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { position: "relative", flex: 1, minHeight: 0 }, children: patchLoading ? /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", height: "100%", gap: 16 }, children: [
+              /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(spinner_default, {}),
+              /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { color: "#666", fontSize: 14 }, children: "Generating patch..." })
+            ] }) : /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)(import_jsx_runtime60.Fragment, { children: [
+              /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { position: "absolute", top: 8, right: 8, zIndex: 2, display: "flex", gap: 8 }, children: [
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
                   button_default,
                   {
                     icon: download_default,
@@ -54977,7 +54988,7 @@ Try "help" for the list of supported commands.
                     }
                   }
                 ),
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
                   button_default,
                   {
                     icon: copy_default,
@@ -54992,12 +55003,12 @@ Try "help" for the list of supported commands.
                   }
                 )
               ] }),
-              /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("pre", { style: { margin: 0, whiteSpace: "pre-wrap", background: "#111", color: "#eee", padding: 12, borderRadius: 6, height: "100%", overflowY: "auto" }, children: patchText && patchText.trim().length ? patchText : "No changes." })
+              /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("pre", { style: { margin: 0, whiteSpace: "pre-wrap", background: "#111", color: "#eee", padding: 12, borderRadius: 6, height: "100%", overflowY: "auto" }, children: patchText && patchText.trim().length ? patchText : "No changes." })
             ] }) })
           ] })
         }
       ),
-      isEmailOpen && activeEmail && /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+      isEmailOpen && activeEmail && /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(
         modal_default,
         {
           title: activeEmail.subject || "Email",
@@ -55007,37 +55018,37 @@ Try "help" for the list of supported commands.
           },
           shouldCloseOnClickOutside: true,
           isFullScreen: true,
-          children: /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { padding: 8 }, children: [
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { marginBottom: 8, fontSize: 12, color: "#444" }, children: [
-              /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { children: [
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("strong", { children: "From:" }),
+          children: /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { padding: 8 }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { style: { marginBottom: 8, fontSize: 12, color: "#444" }, children: [
+              /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { children: [
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("strong", { children: "From:" }),
                 " ",
                 activeEmail.from || ""
               ] }),
-              /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { children: [
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("strong", { children: "To:" }),
+              /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { children: [
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("strong", { children: "To:" }),
                 " ",
                 activeEmail.to || ""
               ] }),
-              activeEmail.cc ? /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { children: [
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("strong", { children: "CC:" }),
+              activeEmail.cc ? /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { children: [
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("strong", { children: "CC:" }),
                 " ",
                 activeEmail.cc
               ] }) : null,
-              /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { children: [
-                /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("strong", { children: "Date:" }),
+              /* @__PURE__ */ (0, import_jsx_runtime60.jsxs)("div", { children: [
+                /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("strong", { children: "Date:" }),
                 " ",
                 activeEmail.sentAt ? new Date(activeEmail.sentAt).toLocaleString() : activeEmail.date ? new Date(activeEmail.date).toLocaleString() : ""
               ] })
             ] }),
-            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(tab_panel_default, { className: "email-tabs", activeClass: "is-active", onSelect: (n) => setEmailViewTab(n), tabs: [{ name: "rendered", title: "Rendered" }, { name: "raw", title: "Raw" }], children: (tab) => tab.name === "rendered" ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { border: "1px solid #ddd", borderRadius: 6, padding: 12, minHeight: "60vh", background: "#fff" }, children: activeEmail.html ? /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { dangerouslySetInnerHTML: { __html: String(activeEmail.html) } }) : /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("pre", { style: { whiteSpace: "pre-wrap", margin: 0 }, children: activeEmail.text || "" }) }) : /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("pre", { style: { whiteSpace: "pre-wrap", margin: 0, background: "#111", color: "#eee", padding: 12, borderRadius: 6, minHeight: "60vh", overflow: "auto" }, children: activeEmail.raw || activeEmail.text || "" }) })
+            /* @__PURE__ */ (0, import_jsx_runtime60.jsx)(tab_panel_default, { className: "email-tabs", activeClass: "is-active", onSelect: (n) => setEmailViewTab(n), tabs: [{ name: "rendered", title: "Rendered" }, { name: "raw", title: "Raw" }], children: (tab) => tab.name === "rendered" ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { style: { border: "1px solid #ddd", borderRadius: 6, padding: 12, minHeight: "60vh", background: "#fff" }, children: activeEmail.html ? /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("div", { dangerouslySetInnerHTML: { __html: String(activeEmail.html) } }) : /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("pre", { style: { whiteSpace: "pre-wrap", margin: 0 }, children: activeEmail.text || "" }) }) : /* @__PURE__ */ (0, import_jsx_runtime60.jsx)("pre", { style: { whiteSpace: "pre-wrap", margin: 0, background: "#111", color: "#eee", padding: 12, borderRadius: 6, minHeight: "60vh", overflow: "auto" }, children: activeEmail.raw || activeEmail.text || "" }) })
           ] })
         }
       )
     ] });
   }
   var root = (0, import_client2.createRoot)(document.getElementById("root"));
-  root.render(/* @__PURE__ */ (0, import_jsx_runtime59.jsx)(App, {}));
+  root.render(/* @__PURE__ */ (0, import_jsx_runtime60.jsx)(App, {}));
 })();
 /*! Bundled license information:
 

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -54000,17 +54000,21 @@ If there's a particular need for this, please submit a feature request at https:
     }, [closeRenameModal]);
     const createdLabel = createdAt ? new Date(createdAt).toLocaleString() : "";
     const [pathCopied, setPathCopied] = (0, import_react69.useState)(false);
+    const copyTimeoutRef = (0, import_react69.useRef)(null);
+    (0, import_react69.useEffect)(() => () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    }, []);
     const copyPath = (0, import_react69.useCallback)(async () => {
       try {
-        if (navigator?.clipboard?.writeText) {
-          await navigator.clipboard.writeText(sitePath);
-          setPathCopied(true);
-          setTimeout(() => setPathCopied(false), 1500);
-        } else {
+        if (!navigator?.clipboard?.writeText) {
           throw new Error("Clipboard access is not available in this environment");
         }
+        await navigator.clipboard.writeText(sitePath);
+        setPathCopied(true);
+        if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+        copyTimeoutRef.current = setTimeout(() => setPathCopied(false), 1500);
       } catch (err) {
-        alert("Unable to copy path: " + err);
+        alert("Unable to copy path: " + (err?.message ?? String(err)));
       }
     }, [sitePath]);
     const appendNpm = (0, import_react69.useCallback)((s) => setNpmLogs((v) => v + s), []);
@@ -54710,7 +54714,7 @@ Try "help" for the list of supported commands.
               {
                 icon: copy_default,
                 label: pathCopied ? "Copied!" : "Copy path",
-                "aria-label": "Copy path",
+                "aria-label": pathCopied ? "Copied!" : "Copy path",
                 onClick: copyPath,
                 variant: "tertiary",
                 isSmall: true

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -53999,6 +53999,20 @@ If there's a particular need for this, please submit a feature request at https:
       }
     }, [closeRenameModal]);
     const createdLabel = createdAt ? new Date(createdAt).toLocaleString() : "";
+    const [pathCopied, setPathCopied] = (0, import_react69.useState)(false);
+    const copyPath = (0, import_react69.useCallback)(async () => {
+      try {
+        if (navigator?.clipboard?.writeText) {
+          await navigator.clipboard.writeText(sitePath);
+          setPathCopied(true);
+          setTimeout(() => setPathCopied(false), 1500);
+        } else {
+          throw new Error("Clipboard access is not available in this environment");
+        }
+      } catch (err) {
+        alert("Unable to copy path: " + err);
+      }
+    }, [sitePath]);
     const appendNpm = (0, import_react69.useCallback)((s) => setNpmLogs((v) => v + s), []);
     const appendRuntime = (0, import_react69.useCallback)((s) => setRuntimeLogs((v) => v + String(s ?? "")), []);
     const sortEmails = (0, import_react69.useCallback)((list) => [...list].sort((a, b) => new Date(b.sentAt || b.date || 0) - new Date(a.sentAt || a.date || 0)), []);
@@ -54688,6 +54702,20 @@ Try "help" for the list of supported commands.
               "Created ",
               createdLabel
             ] }) : null
+          ] }),
+          /* @__PURE__ */ (0, import_jsx_runtime59.jsxs)("div", { style: { display: "flex", alignItems: "center", gap: 4, marginTop: 6 }, children: [
+            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("code", { style: { fontSize: 12, color: "#3c434a", background: "#f0f0f1", padding: "2px 6px", borderRadius: 4, overflowWrap: "anywhere" }, children: sitePath }),
+            /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
+              button_default,
+              {
+                icon: copy_default,
+                label: pathCopied ? "Copied!" : "Copy path",
+                "aria-label": "Copy path",
+                onClick: copyPath,
+                variant: "tertiary",
+                isSmall: true
+              }
+            )
           ] })
         ] }),
         /* @__PURE__ */ (0, import_jsx_runtime59.jsx)("div", { style: { display: "flex", alignItems: "flex-start", gap: 8 }, children: /* @__PURE__ */ (0, import_jsx_runtime59.jsx)(
@@ -54696,20 +54724,7 @@ Try "help" for the list of supported commands.
             label: "More",
             text: "",
             controls: [
-              {
-                title: "Copy path",
-                onClick: async () => {
-                  try {
-                    if (navigator?.clipboard?.writeText) {
-                      await navigator.clipboard.writeText(sitePath);
-                    } else {
-                      throw new Error("Clipboard access is not available in this environment");
-                    }
-                  } catch (err) {
-                    alert("Unable to copy path: " + err);
-                  }
-                }
-              },
+              { title: "Copy path", onClick: copyPath },
               { title: "Forget this site", onClick: () => confirmAnd("Remove this site from the list?", () => onForget(sitePath)) },
               { title: "Delete this site", onClick: () => confirmAnd("Delete this site from disk? This cannot be undone.", () => onDelete(sitePath)) }
             ]

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -11,7 +11,7 @@ import {
   TextControl,
   Spinner
 } from '@wordpress/components';
-import { plus, chevronLeft, chevronRight, copy as copyIcon, edit, download } from '@wordpress/icons';
+import { plus, chevronLeft, chevronRight, copy as copyIcon, check as checkIcon, edit, download } from '@wordpress/icons';
 import '@wordpress/components/build-style/style.css';
 import { Terminal } from 'xterm';
 import 'xterm/css/xterm.css';
@@ -1427,7 +1427,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
               {sitePath}
             </code>
             <Button
-              icon={copyIcon}
+              icon={pathCopied ? checkIcon : copyIcon}
               label={pathCopied ? 'Copied!' : 'Copy path'}
               aria-label={pathCopied ? 'Copied!' : 'Copy path'}
               onClick={copyPath}

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -740,6 +740,20 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
     }
   }, [closeRenameModal]);
   const createdLabel = createdAt ? new Date(createdAt).toLocaleString() : '';
+  const [pathCopied, setPathCopied] = useState(false);
+  const copyPath = useCallback(async () => {
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(sitePath);
+        setPathCopied(true);
+        setTimeout(() => setPathCopied(false), 1500);
+      } else {
+        throw new Error('Clipboard access is not available in this environment');
+      }
+    } catch (err) {
+      alert('Unable to copy path: ' + err);
+    }
+  }, [sitePath]);
 
   const appendNpm = useCallback((s)=>setNpmLogs((v)=>v+s),[]);
   const appendRuntime = useCallback((s)=>setRuntimeLogs((v)=>v + String(s ?? '')),[]);
@@ -1402,26 +1416,26 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
             </span>
             {createdLabel ? <span>Created {createdLabel}</span> : null}
           </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 6 }}>
+            <code style={{ fontSize: 12, color: '#3c434a', background: '#f0f0f1', padding: '2px 6px', borderRadius: 4, overflowWrap: 'anywhere' }}>
+              {sitePath}
+            </code>
+            <Button
+              icon={copyIcon}
+              label={pathCopied ? 'Copied!' : 'Copy path'}
+              aria-label="Copy path"
+              onClick={copyPath}
+              variant="tertiary"
+              isSmall
+            />
+          </div>
         </div>
         <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
           <DropdownMenu
             label="More"
             text=""
             controls={[
-              {
-                title: 'Copy path',
-                onClick: async () => {
-                  try {
-                    if (navigator?.clipboard?.writeText) {
-                      await navigator.clipboard.writeText(sitePath);
-                    } else {
-                      throw new Error('Clipboard access is not available in this environment');
-                    }
-                  } catch (err) {
-                    alert('Unable to copy path: ' + err);
-                  }
-                }
-              },
+              { title: 'Copy path', onClick: copyPath },
               { title:'Forget this site', onClick:()=>confirmAnd('Remove this site from the list?', ()=>onForget(sitePath)) },
               { title:'Delete this site', onClick:()=>confirmAnd('Delete this site from disk? This cannot be undone.', ()=>onDelete(sitePath)) }
             ]}

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -1423,7 +1423,7 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
             <Button
               icon={copyIcon}
               label={pathCopied ? 'Copied!' : 'Copy path'}
-              aria-label="Copy path"
+              aria-label={pathCopied ? 'Copied!' : 'Copy path'}
               onClick={copyPath}
               variant="tertiary"
               isSmall

--- a/src/renderer/index.jsx
+++ b/src/renderer/index.jsx
@@ -741,17 +741,23 @@ function SiteRow({ sitePath, initialized, createdAt, label, onInitialized, onFor
   }, [closeRenameModal]);
   const createdLabel = createdAt ? new Date(createdAt).toLocaleString() : '';
   const [pathCopied, setPathCopied] = useState(false);
+  const copyTimeoutRef = useRef(null);
+
+  useEffect(() => () => {
+    if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+  }, []);
+
   const copyPath = useCallback(async () => {
     try {
-      if (navigator?.clipboard?.writeText) {
-        await navigator.clipboard.writeText(sitePath);
-        setPathCopied(true);
-        setTimeout(() => setPathCopied(false), 1500);
-      } else {
+      if (!navigator?.clipboard?.writeText) {
         throw new Error('Clipboard access is not available in this environment');
       }
+      await navigator.clipboard.writeText(sitePath);
+      setPathCopied(true);
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setPathCopied(false), 1500);
     } catch (err) {
-      alert('Unable to copy path: ' + err);
+      alert('Unable to copy path: ' + (err?.message ?? String(err)));
     }
   }, [sitePath]);
 


### PR DESCRIPTION
## Summary

Follow-up to #26. As raised in [review](https://github.com/WordPress/experimental-wp-dev-env/pull/26#pullrequestreview-4639851048), removing the editor-detection dropdown means everyone now has to fall back to copying the site path manually — but that path was only reachable through the "More" menu. This surfaces it inline in the site header for quick access, with a one-click copy button (and "Copied!" feedback).

<img width="995" height="700" alt="CleanShot 2026-07-07 at 10 49 34" src="https://github.com/user-attachments/assets/c7306e29-8055-4ee1-8a05-548ce6d10012" />


## Changes

- `src/renderer/index.jsx` (+ rebuilt `index.js` bundle): added inline path display + copy button in the `SiteRow` header; the "More → Copy path" menu item now reuses the same `copyPath` handler instead of duplicating the clipboard logic.

## Test plan

- [ ] Confirm the site path is visible inline in the site header.
- [ ] Confirm clicking the copy button copies the path and shows "Copied!" briefly.
- [ ] Confirm "More → Copy path" still works.
- [ ] Confirm the app builds and runs via `npm start` with no console errors.

Base branch is `remove/editor-detection-dropdown` since this builds on top of it; GitHub will retarget to `trunk` automatically once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)